### PR TITLE
Move advanced header options to modal

### DIFF
--- a/src/lanscape/ui/static/js/main.js
+++ b/src/lanscape/ui/static/js/main.js
@@ -39,6 +39,10 @@ $(document).ready(function() {
         $('#ip-table-frame').attr('src', newSrc);
     });
 
+    $('#settings-btn').on('click', function() {
+        $('#advancedModal').modal('show');
+    });
+
 });
 
 function submitNewScan() {

--- a/src/lanscape/ui/templates/main.html
+++ b/src/lanscape/ui/templates/main.html
@@ -3,9 +3,9 @@
 {% block content %}
 <div id="header">
       <!-- Header and Scan Submission Inline -->
-    <div class="d-flex justify-content-between align-items-center flex-wrap">
+    <div class="d-flex justify-content-between align-items-center flex-nowrap">
         <h1 class="title" onclick="location.reload()">
-            <span>LAN</span>scape 
+            <span>LAN</span>scape
         </h1>
         <!-- Form -->
         <form id="scan-form" class="d-flex align-items-end">
@@ -26,11 +26,30 @@
             </div>
             <button type="submit" id="scan-submit" class="btn btn-primary mb-3">Scan</button>
         </form>
+
+        <span
+            id="settings-btn"
+            class="material-symbols-outlined secondary-icon-btn ms-2"
+            data-bs-toggle="tooltip"
+            data-bs-placement="top"
+            title="Advanced scan settings"
+        >
+            settings
+        </span>
     </div>
 
-    <!-- Advanced Section -->
-    <details onclick="rightSizeDocLayout()">
-        <summary>Advanced</summary>
+    <div id="scan-progress-bar"></div>
+</div>
+
+<!-- Advanced Settings Modal -->
+<div class="modal fade" id="advancedModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="advancedModalLabel">Advanced Settings</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
         <div class="form-group mt-2">
             <label for="port_list">Port List:</label>
             <div class="port-list-wrapper">
@@ -38,14 +57,18 @@
                 <div id="port-list-dropdown" class="port-list-dropdown"></div>
             </div>
         </div>
-        
+
         <div class="form-group mt-2">
             <label for="parallelism">Parallelism:</label>
             <input type="range" id="parallelism" name="parallelism" min="0.25" max="3" step="0.05" value="{{parallelism}}">
             <output id="parallelism-value">{{parallelism}}</output>
         </div>
-    </details>
-    <div id="scan-progress-bar"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
 </div>
 <div id="content">
     <div class="container-fluid my-4">

--- a/src/lanscape/ui/templates/main.html
+++ b/src/lanscape/ui/templates/main.html
@@ -8,7 +8,7 @@
             <span>LAN</span>scape
         </h1>
         <!-- Right side: settings + form -->
-        <div class="d-flex align-items-end justify-content-end ms-auto">
+        <div class="d-flex align-items-center justify-content-end ms-auto">
             <span
                 id="settings-btn"
                 class="material-symbols-outlined secondary-icon-btn me-2"
@@ -18,7 +18,7 @@
             >
                 settings
             </span>
-        <form id="scan-form" class="d-flex align-items-end">
+        <form id="scan-form" class="d-flex align-items-center">
             <div class="form-group me-2">
                 <div class="label-container">
                     <label for="subnet">Subnet:</label>

--- a/src/lanscape/ui/templates/main.html
+++ b/src/lanscape/ui/templates/main.html
@@ -7,7 +7,17 @@
         <h1 class="title" onclick="location.reload()">
             <span>LAN</span>scape
         </h1>
-        <!-- Form -->
+        <!-- Right side: settings + form -->
+        <div class="d-flex align-items-end justify-content-end ms-auto">
+            <span
+                id="settings-btn"
+                class="material-symbols-outlined secondary-icon-btn me-2"
+                data-bs-toggle="tooltip"
+                data-bs-placement="top"
+                title="Advanced scan settings"
+            >
+                settings
+            </span>
         <form id="scan-form" class="d-flex align-items-end">
             <div class="form-group me-2">
                 <div class="label-container">
@@ -26,16 +36,7 @@
             </div>
             <button type="submit" id="scan-submit" class="btn btn-primary mb-3">Scan</button>
         </form>
-
-        <span
-            id="settings-btn"
-            class="material-symbols-outlined secondary-icon-btn ms-2"
-            data-bs-toggle="tooltip"
-            data-bs-placement="top"
-            title="Advanced scan settings"
-        >
-            settings
-        </span>
+        </div>
     </div>
 
     <div id="scan-progress-bar"></div>
@@ -44,10 +45,10 @@
 <!-- Advanced Settings Modal -->
 <div class="modal fade" id="advancedModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
+    <div class="modal-content bg-dark text-light">
+      <div class="modal-header border-secondary">
         <h5 class="modal-title" id="advancedModalLabel">Advanced Settings</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
         <div class="form-group mt-2">
@@ -64,7 +65,7 @@
             <output id="parallelism-value">{{parallelism}}</output>
         </div>
       </div>
-      <div class="modal-footer">
+      <div class="modal-footer border-secondary">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- convert the advanced scan options from a `<details>` spoiler to a Bootstrap modal
- add a settings icon in the header that opens the new modal
- keep existing ids for options so state saving works

## Testing
- `pip install -q -r requirements.txt`
- `pytest -k "nothing" -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685a0f6db130832aaf28267f4ed21a3e