### PR TITLE
1.3.1 - MacOS support & Networking Enhancements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lanscape"
-version = "1.3.1a6"
+version = "1.3.1a7"
 authors = [
   { name="Michael Dennis", email="michael@dipduo.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lanscape"
-version = "1.3.1a7"
+version = "1.3.1"
 authors = [
   { name="Michael Dennis", email="michael@dipduo.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lanscape"
-version = "1.3.0"
+version = "1.3.1a6"
 authors = [
   { name="Michael Dennis", email="michael@dipduo.com" },
 ]

--- a/src/lanscape/libraries/net_tools.py
+++ b/src/lanscape/libraries/net_tools.py
@@ -443,7 +443,6 @@ def smart_select_primary_subnet(subnets: List[dict] | None = None) -> str:
         
     # First priority: Get subnet for the primary interface
     primary_if = get_primary_interface()
-    print(f"Primary interface: {primary_if}")
     if primary_if:
         primary_subnet = get_network_subnet(primary_if)
         if primary_subnet:

--- a/src/lanscape/libraries/net_tools.py
+++ b/src/lanscape/libraries/net_tools.py
@@ -76,7 +76,7 @@ class IPAlive:
         if os_name == "windows":
             # -n count, -w timeout in ms
             cmd = ['ping', '-n', str(ping_count), '-w', str(timeout*1000)]
-        else:
+        else:  # Linux, macOS, and other Unix-like systems
             # -c count, -W timeout in s
             cmd = ['ping', '-c', str(ping_count), '-W', str(timeout)]
 
@@ -211,9 +211,9 @@ mac_selector = MacSelector()
 
 def get_ip_address(interface: str):
     """
-    Get the IP address of a network interface on Windows or Linux.
+    Get the IP address of a network interface on Windows, Linux, or macOS.
     """
-    def linux():
+    def unix_like():  # Combined Linux and macOS
         try:
             import fcntl
             import struct
@@ -239,17 +239,15 @@ def get_ip_address(interface: str):
     # Call the appropriate function based on the platform
     if psutil.WINDOWS:
         return windows()
-    elif psutil.LINUX:
-        return linux()
-    else:
-        return None
+    else:  # Linux, macOS, and other Unix-like systems
+        return unix_like()
 
 def get_netmask(interface: str):
     """
     Get the netmask of a network interface.
     """
     
-    def linux():
+    def unix_like():  # Combined Linux and macOS
         try:
             import fcntl
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -273,7 +271,8 @@ def get_netmask(interface: str):
     
     if psutil.WINDOWS:
         return windows()
-    return linux()
+    else:  # Linux, macOS, and other Unix-like systems
+        return unix_like()
 
 def get_cidr_from_netmask(netmask: str):
     """

--- a/src/lanscape/libraries/net_tools.py
+++ b/src/lanscape/libraries/net_tools.py
@@ -347,17 +347,24 @@ def get_all_network_subnets():
 
     return subnets
 
-def smart_select_primary_subnet(subnets: List[dict]=get_all_network_subnets()) -> str:
+def smart_select_primary_subnet(subnets: List[dict] | None = None) -> str:
     """
-     Finds the largest subnet within max ip range
-     not perfect, but works better than subnets[0]
+    Finds the largest subnet within max ip range. If no subnets are
+    available, returns an empty string instead of raising ``KeyError``.
     """
+    subnets = subnets or get_all_network_subnets()
+
+    if not subnets:
+        return ""
+
     selected = {}
     for subnet in subnets:
-        if selected.get('address_cnt',0) < subnet['address_cnt'] < MAX_IPS_ALLOWED:
+        if selected.get("address_cnt", 0) < subnet["address_cnt"] < MAX_IPS_ALLOWED:
             selected = subnet
-    if not selected and len(subnets):
+
+    if not selected:
         selected = subnets[0]
-    return selected['subnet']
+
+    return selected.get("subnet", "")
 
 

--- a/src/lanscape/libraries/net_tools.py
+++ b/src/lanscape/libraries/net_tools.py
@@ -9,7 +9,9 @@ import traceback
 import subprocess
 from time import sleep
 from typing import List, Dict
-from scapy.all import ARP, Ether, srp
+from scapy.sendrecv import srp
+from scapy.layers.l2 import ARP, Ether
+from scapy.error import Scapy_Exception
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .service_scan import scan_service
@@ -66,7 +68,7 @@ class IPAlive:
 
     def _ping_lookup(
         self, host: str,
-        retries: int = 1,
+        retries: int = 2,
         retry_delay: int = .25,
         ping_count: int = 2,
         timeout: int = 2
@@ -80,16 +82,31 @@ class IPAlive:
             # -c count, -W timeout in s
             cmd = ['ping', '-c', str(ping_count), '-W', str(timeout)]
 
+        cmd = cmd + [host]
+
         for r in range(retries):
             try:
-                output = subprocess.check_output(
-                    cmd + [host],
-                    stderr=subprocess.STDOUT,
-                    universal_newlines=True
+                proc = subprocess.run(
+                    cmd,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE
                 )
-                # Windows/Linux both include “TTL” on a successful reply
-                if 'TTL' in output.upper():
-                    return True
+                
+                if proc.returncode == 0:
+                    output = proc.stdout.lower()
+
+                    # Windows/Linux both include “TTL” on a successful reply
+                    if psutil.WINDOWS or psutil.LINUX:
+                        if 'ttl' in output:
+                            return True
+                    # some distributions of Linux and macOS
+                    if psutil.MACOS or psutil.LINUX:
+                        bad = '100.0% packet loss'
+                        good = 'ping statistics'
+                        # mac doesnt include TTL, so we check good is there, and bad is not
+                        if good in output and bad not in output:
+                            return True
             except subprocess.CalledProcessError as e:
                 self.caught_errors.append(DeviceError(e))
                 pass
@@ -306,25 +323,25 @@ def get_host_ip_mask(ip_with_cidr: str):
     network = ipaddress.ip_network(ip_with_cidr, strict=False)
     return f'{network.network_address}/{cidr}'
 
-def get_network_subnet(interface = get_primary_interface()):
+def get_network_subnet(interface = None):
     """
-    Get the network interface and subnet.
-    Default is primary interface
-    """ 
+    Get the network subnet for a given interface.
+    Uses network_from_snicaddr for conversion.
+    Default is primary interface.
+    """
+    interface = interface or get_primary_interface()
     try:
-        ip_address = get_ip_address(interface)
-        netmask = get_netmask(interface)
-        # is valid interface?
-        if ip_address and netmask:
-            cidr = get_cidr_from_netmask(netmask)
-
-            ip_mask = f'{ip_address}/{cidr}'
-
-            return get_host_ip_mask(ip_mask)
-    except:
+        addrs = psutil.net_if_addrs()
+        if interface in addrs:
+            for snicaddr in addrs[interface]:
+                if snicaddr.family == socket.AF_INET and snicaddr.address and snicaddr.netmask:
+                    subnet = network_from_snicaddr(snicaddr)
+                    if subnet:
+                        return subnet
+    except Exception:
         log.info(f'Unable to parse subnet for interface: {interface}')
         log.debug(traceback.format_exc())
-    return
+    return None
 
 def get_all_network_subnets():
     """
@@ -337,7 +354,9 @@ def get_all_network_subnets():
     for interface, snicaddrs in addrs.items():
         for snicaddr in snicaddrs:
             if snicaddr.family == socket.AF_INET and gateways[interface].isup:
-                subnet = get_network_subnet(interface)
+
+                subnet = network_from_snicaddr(snicaddr)
+
                 if subnet: 
                     subnets.append({ 
                         'subnet': subnet, 
@@ -345,6 +364,20 @@ def get_all_network_subnets():
                     })
 
     return subnets
+
+def network_from_snicaddr(snicaddr: psutil._common.snicaddr) -> str:
+    """
+    Convert a psutil snicaddr object to a human-readable string.
+    """
+    if not snicaddr.address or not snicaddr.netmask:
+        return None
+    elif snicaddr.family == socket.AF_INET:
+        addr = f"{snicaddr.address}/{get_cidr_from_netmask(snicaddr.netmask)}"
+    elif snicaddr.family == socket.AF_INET6:
+        addr = f"{snicaddr.address}/{snicaddr.netmask}"
+    else:
+        return f"{snicaddr.address}"
+    return get_host_ip_mask(addr)
 
 def smart_select_primary_subnet(subnets: List[dict] | None = None) -> str:
     """
@@ -365,5 +398,19 @@ def smart_select_primary_subnet(subnets: List[dict] | None = None) -> str:
         selected = subnets[0]
 
     return selected.get("subnet", "")
+
+def is_arp_supported():
+    """
+    Check if ARP requests are supported on the current platform.
+    """
+    try:
+        arp_request = ARP(pdst='0.0.0.0')
+        broadcast   = Ether(dst="ff:ff:ff:ff:ff:ff")
+        packet      = broadcast / arp_request
+
+        srp(packet, timeout=0, verbose=False)
+        return True
+    except Scapy_Exception:
+        return False
 
 

--- a/src/lanscape/libraries/subnet_scan.py
+++ b/src/lanscape/libraries/subnet_scan.py
@@ -12,7 +12,7 @@ from tabulate import tabulate
 from dataclasses import dataclass
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from .net_tools import Device
+from .net_tools import Device, is_arp_supported
 from .ip_parser import parse_ip_input
 from .port_manager import PortManager
 from.errors import SubnetScanTerminationFailure
@@ -80,6 +80,8 @@ class SubnetScanner:
         self.uid = str(uuid.uuid4())
         self.results = ScannerResults(self)
         self.log: logging.Logger = logging.getLogger('SubnetScanner')
+        if not is_arp_supported():
+            self.log.warning('ARP is not supported with the active runtime context. Device discovery will be limited to ping responses.')
         self.log.debug(f'Instantiated with uid: {self.uid}')
         self.log.debug(f'Port Count: {len(self.ports)} | Device Count: {len(self.subnet)}')
 

--- a/src/lanscape/libraries/version_manager.py
+++ b/src/lanscape/libraries/version_manager.py
@@ -33,7 +33,7 @@ def lookup_latest_version(package=PACKAGE):
         no_cache = f'?cachebust={randint(0,6969)}'
         url = f"https://pypi.org/pypi/{package}/json{no_cache}"
         try:
-            response = requests.get(url)
+            response = requests.get(url,timeout=5)
             response.raise_for_status()  # Raise an exception for HTTP errors
             latest = response.json()['info']['version']
             log.debug(f'Latest pypi version: {latest}')

--- a/src/lanscape/libraries/web_browser.py
+++ b/src/lanscape/libraries/web_browser.py
@@ -29,6 +29,13 @@ def open_webapp(url: str) -> bool:
     """
     start = time.time()
     try:
+        if sys.platform.startswith("darwin"):
+            # macOS does not support chrome-style app mode via the generic
+            # method. Fallback to the system "open" command which will use the
+            # default browser.
+            subprocess.run(["open", url], check=True)
+            return True
+
         exe = get_default_browser_executable()
         if not exe:
             raise RuntimeError('Unable to find browser binary')
@@ -117,8 +124,12 @@ def get_default_browser_executable() -> Optional[str]:
                             # strip arguments like “%u”, “--flag”, etc.
                             exec_cmd = exec_cmd.split()[0]
                             exec_cmd = exec_cmd.split("%")[0]
-                            return exec_cmd
+            return exec_cmd
         return None
+
+    elif sys.platform.startswith("darwin"):
+        # macOS will use the system 'open' command to launch the default browser
+        return "/usr/bin/open"
 
     else:
         raise NotImplementedError(f"Unsupported platform: {sys.platform!r}")

--- a/src/lanscape/tests/test_env.py
+++ b/src/lanscape/tests/test_env.py
@@ -2,6 +2,7 @@ import unittest
 
 from ..libraries.version_manager import lookup_latest_version 
 from ..libraries.app_scope import ResourceManager, is_local_run
+from ..libraries.net_tools import is_arp_supported
 
 
 
@@ -20,5 +21,10 @@ class EnvTestCase(unittest.TestCase):
     def test_local_version(self):
         self.assertTrue(is_local_run())
         
+    def test_arp_support(self):
+        arp_supported = is_arp_supported()
+        self.assertIn(arp_supported, [True, False],
+            f"ARP support should be either True or False, not {arp_supported}"
+        )
         
 

--- a/src/lanscape/ui/app.py
+++ b/src/lanscape/ui/app.py
@@ -9,6 +9,7 @@ import os
 from ..libraries.runtime_args import RuntimeArgs, parse_args
 from ..libraries.version_manager import is_update_available, get_installed_version, lookup_latest_version
 from ..libraries.app_scope import is_local_run
+from ..libraries.net_tools import is_arp_supported
 
 app = Flask(
     __name__
@@ -57,6 +58,7 @@ set_global_safe('update_available', is_update_available)
 set_global_safe('latest_version',lookup_latest_version)
 set_global_safe('runtime_args', vars(parse_args()))
 set_global_safe('is_local',is_local_run)
+set_global_safe('is_arp_supported', is_arp_supported)
 
 ## External hook to kill flask server
 ################################

--- a/src/lanscape/ui/main.py
+++ b/src/lanscape/ui/main.py
@@ -46,8 +46,7 @@ def _main():
     args.port = get_valid_port(args.port)
 
     if not is_arp_supported():
-        log.warning('ARP is not supported, device discovery is degraded.')
-        log.warning('Help guide: https://github.com/mdennis281/LANscape/blob/main/support/arp-issues.md')
+        log.warning('ARP is not supported, device discovery is degraded. For more information, see the help guide: https://github.com/mdennis281/LANscape/blob/main/support/arp-issues.md')
 
     try:
         start_webserver_ui(args)

--- a/src/lanscape/ui/main.py
+++ b/src/lanscape/ui/main.py
@@ -7,6 +7,7 @@ import os
 from ..libraries.logger import configure_logging
 from ..libraries.runtime_args import parse_args, RuntimeArgs
 from ..libraries.web_browser import open_webapp
+from ..libraries.net_tools import is_arp_supported
 # do this so any logs generated on import are displayed
 args = parse_args()
 configure_logging(args.loglevel, args.logfile, args.flask_logging)
@@ -43,8 +44,11 @@ def _main():
         log.info('Flask reloaded app.')
         
     args.port = get_valid_port(args.port)
-        
-        
+
+    if not is_arp_supported():
+        log.warning('ARP is not supported, device discovery is degraded.')
+        log.warning('Help guide: https://github.com/mdennis281/LANscape/blob/main/support/arp-issues.md')
+
     try:
         start_webserver_ui(args)
         log.info('Exiting...')

--- a/src/lanscape/ui/static/css/style.css
+++ b/src/lanscape/ui/static/css/style.css
@@ -56,7 +56,7 @@ body:has(.submodule) footer {
     background-color: var(--primary-bg);
     border-radius: 8px;
     box-shadow: 0 0 10px var(--box-shadow);
-    width: 90%;
+    width: 95%;
     margin-top: 10px;
     overflow: hidden; 
 }

--- a/src/lanscape/ui/static/css/style.css
+++ b/src/lanscape/ui/static/css/style.css
@@ -11,6 +11,8 @@
     --danger-accent: #ff5252; /* Bright red for warnings */
     --danger-accent-hover: #e64545;
 
+    --danger-accent-transparent: rgba(255, 82, 82, 0.3);/* Light red for subtle danger indication */
+
     --warning-accent: #cc8801; /* Vibrant amber for warnings */
     --warning-accent-hover: #d08802;
 
@@ -56,6 +58,7 @@ body:has(.submodule) footer {
     box-shadow: 0 0 10px var(--box-shadow);
     width: 90%;
     margin-top: 10px;
+    overflow: hidden; 
 }
 
 #header {
@@ -255,18 +258,7 @@ details {
 
 
 
-@media screen and (max-width: 681px) {
-    #power-button {
-        left: auto;
-        right: 0;
-        border-width: 0 0 1px 1px;
-        border-radius: 0 0 0 5px;
-    }
-    .container-fluid {
-        width:98%;
-        padding: 8px;
-    }
-}
+
 
 /* Card Styles */
 .card {
@@ -692,7 +684,36 @@ html {
     background-color: var(--warning-accent);
 }
 
-/* width of iFrame, not page */
+#arp-error {
+    width: calc(100% + 40px);
+    position: relative;
+    display: flex;
+    justify-content: center;
+    background-color: var(--danger-accent-transparent);
+    color: var(--text-color);
+    transform: translate3d(-20px, -20px, 0);
+    font-size: small;
+}
+#arp-error span {
+    text-align: center;
+}
+
+@media screen and (max-width: 681px) {
+    #power-button {
+        left: auto;
+        right: 0;
+        border-width: 0 0 1px 1px;
+        border-radius: 0 0 0 5px;
+    }
+    .container-fluid {
+        width:98%;
+        padding: 8px;
+    }
+    #arp-error {
+        width: calc(100% + 16px);
+        transform: translate3d(-8px, -8px, 0);
+    }
+}
 
 @media screen and (max-width: 885px) {
     #overview-container .col-4 {

--- a/src/lanscape/ui/templates/core/scripts.html
+++ b/src/lanscape/ui/templates/core/scripts.html
@@ -3,4 +3,7 @@
 <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
 <script src="{{ url_for('static', filename='js/core.js') }}"></script>
+
+{% if not section is defined %}
 <script src="{{ url_for('static', filename='js/on-tab-close.js') }}"></script>
+{% endif %}

--- a/src/lanscape/ui/templates/core/scripts.html
+++ b/src/lanscape/ui/templates/core/scripts.html
@@ -4,6 +4,6 @@
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
 <script src="{{ url_for('static', filename='js/core.js') }}"></script>
 
-{% if not section is defined %}
+{% if section is not defined %}
 <script src="{{ url_for('static', filename='js/on-tab-close.js') }}"></script>
 {% endif %}

--- a/src/lanscape/ui/templates/info.html
+++ b/src/lanscape/ui/templates/info.html
@@ -4,7 +4,7 @@
 <div id="header">
       <!-- Header and Scan Submission Inline -->
     <div class="d-flex justify-content-start align-items-center">
-        <a href="/" class="text-decoration-none">
+        <a href="/" class="text-decoration-none" aria-label="Go to homepage">
             <h1 class="title">
                 <span>LAN</span>scape 
             </h1>

--- a/src/lanscape/ui/templates/info.html
+++ b/src/lanscape/ui/templates/info.html
@@ -4,9 +4,11 @@
 <div id="header">
       <!-- Header and Scan Submission Inline -->
     <div class="d-flex justify-content-start align-items-center">
-        <h1 class="title" onclick="location.href = '/'">
-            <span>LAN</span>scape 
-        </h1>
+        <a href="/" class="text-decoration-none">
+            <h1 class="title">
+                <span>LAN</span>scape 
+            </h1>
+        </a>
     </div>
 </div>
 <div class="scroll-container" id="content">
@@ -18,7 +20,7 @@
             ({{app_version}} -> {{latest_version}})
         </p>
         <input type="text" readonly class="form-control mb-3 mt-3" value="pip install --upgrade lanscape --no-cache"/>
-        <a  href="https://pypi.org/project/lanscape/" target="_blank"></a>
+        <a class="text-decoration-none" href="https://pypi.org/project/lanscape/" target="_blank">
             <button class="btn btn-primary m-2">PyPi - Lanscape</button>
         </a>
     </div>  
@@ -33,10 +35,10 @@
             This project has been a learning journey, & I hope it helps you 
             discover more about your network as well. Enjoy!
         </p>
-        <a  href="https://github.com/mdennis281/" target="_blank">
+        <a  href="https://github.com/mdennis281/" class="text-decoration-none" target="_blank">
             <button class="btn btn-primary m-2">GitHub</button>
         </a>
-        <a  href="https://github.com/mdennis281/LANscape" target="_blank">
+        <a  href="https://github.com/mdennis281/LANscape" class="text-decoration-none" target="_blank">
             <button class="btn btn-secondary m-2">Project Repo</button>
         </a>
     </div>  

--- a/src/lanscape/ui/templates/main.html
+++ b/src/lanscape/ui/templates/main.html
@@ -52,7 +52,7 @@
         <!-- ARP Error -->
         <div id="arp-error" class="{{ 'div-hide' if is_arp_supported else '' }}">
             <span>
-                Unable to discover devices using ARP. Device discovery is degraded.
+                Unable to use ARP lookup. Device discovery is degraded.
                 <a target="_blank" href="https://github.com/mdennis281/LANscape/blob/main/support/arp-issues.md">Steps to fix</a>
             </span>
         </div>

--- a/src/lanscape/ui/templates/main.html
+++ b/src/lanscape/ui/templates/main.html
@@ -49,6 +49,13 @@
 </div>
 <div id="content">
     <div class="container-fluid my-4">
+        <!-- ARP Error -->
+        <div id="arp-error" class="{{ 'div-hide' if is_arp_supported else '' }}">
+            <span>
+                Unable to discover devices using ARP. Device discovery is degraded.
+                <a target="_blank" href="https://github.com/mdennis281/LANscape/blob/main/support/arp-issues.md">Steps to fix</a>
+            </span>
+        </div>
         <!-- Scan Results -->
         <div id="scan-results" class="div-hide">
             <div class="d-flex justify-content-between">

--- a/support/arp-issues.md
+++ b/support/arp-issues.md
@@ -1,0 +1,13 @@
+## What is ARP (Address Resolution Protocol)
+ARP (Address Resolution Protocol) is a network protocol used to map an IP address to a physical machine address (MAC address) on a local area network. When a device wants to communicate with another device on the same network, it uses ARP to discover the MAC address associated with the target IP address. This process enables devices to send data to the correct hardware on the network.
+
+## Why do we use it?
+While tools like `ping` can be used to check if a device is reachable on the network, they rely on the target device responding to ICMP echo requests. Devices can be configured to ignore or block these requests, making `ping` an unreliable method for discovering devices or their addresses. ARP, on the other hand, operates at a lower level and is necessary for actual data transmission, regardless of whether a device responds to `ping`. This makes ARP a more reliable mechanism for mapping IP addresses to MAC addresses on a local network.
+
+
+## Getting it working (Mac/Linux)
+Unfortunately the only known solution to get python Scapy (ARP lookup library) working on unix machines is to run the program as root. If you arent comfortable with this, there is a ping mechanism used as a backup in the code that will be invoked on a failed ARP lookup.
+
+## Getting it working (Windows)
+Windows doesn't need any special elevation, but it does need a dependency installed on your computer
+[npcap download](https://npcap.com/#download)

--- a/support/arp-issues.md
+++ b/support/arp-issues.md
@@ -6,7 +6,7 @@ While tools like `ping` can be used to check if a device is reachable on the net
 
 
 ## Getting it working (Mac/Linux)
-Unfortunately the only known solution to get python Scapy (ARP lookup library) working on unix machines is to run the program as root. If you arent comfortable with this, there is a ping mechanism used as a backup in the code that will be invoked on a failed ARP lookup.
+Unfortunately the only known solution to get python Scapy (ARP lookup library) working on unix machines is to run the program as root. If you aren't comfortable with this, there is a ping mechanism used as a backup in the code that will be invoked on a failed ARP lookup.
 
 ## Getting it working (Windows)
 Windows doesn't need any special elevation, but it does need a dependency installed on your computer


### PR DESCRIPTION
## Pull Request Overview

**note: a small portion of this PR was made by ChatGPT codex, but the vast majority of it was manual

This PR enhances macOS support for launching the web UI, integrates ARP-support detection into the UI and server logs, and prevents errors when no network subnets are found.
- Add macOS detection in `web_browser.py` and strengthen subprocess calls
- Introduce `is_arp_supported` and wire it through templates, logs, and CSS/JS UI indicators
- Refactor subnet-scanning functions to safely handle missing subnets and bump version

### Reviewed Changes

<details>
<summary>Show a summary per file</summary>

| File                                              | Description                                                 |
|---------------------------------------------------|-------------------------------------------------------------|
| support/arp-issues.md                             | Document ARP issues and troubleshooting steps               |
| src/lanscape/ui/templates/main.html               | Display ARP-error banner when ARP is unsupported            |
| src/lanscape/ui/templates/info.html               | Wrap title in link and add styling classes                  |
| src/lanscape/ui/templates/core/scripts.html       | Conditionally include tab-close script block                |
| src/lanscape/ui/static/js/on-tab-close.js         | Enhance unload handling for pagehide events                 |
| src/lanscape/ui/static/css/style.css              | Add styling for ARP-error banner and layout adjustments     |
| src/lanscape/ui/main.py                           | Log warnings if ARP is unsupported on startup               |
| src/lanscape/ui/app.py                            | Expose `is_arp_supported` flag to templates                 |
| src/lanscape/tests/test_env.py                    | Add basic test for ARP support flag                         |
| src/lanscape/libraries/web_browser.py             | Detect Chrome on macOS and adjust subprocess invocation     |
| src/lanscape/libraries/version_manager.py         | Add request timeout for PyPI version lookup                 |
| src/lanscape/libraries/subnet_scan.py             | Warn when ARP is unavailable during scanning                |
| src/lanscape/libraries/net_tools.py               | Refactor subnet utilities and implement `is_arp_supported`  |
| pyproject.toml                                    | Bump version to 1.3.1                                    |
</details>

