### PR TITLE
Add full scan configuration controls

### DIFF
--- a/lanscape/ui/blueprints/web/routes.py
+++ b/lanscape/ui/blueprints/web/routes.py
@@ -16,12 +16,10 @@ def index():
     subnet = smart_select_primary_subnet(subnets)
 
     port_list = 'medium'
-    parallelism = 1
     if scan_id := request.args.get('scan_id'):
         if scan := scan_manager.get_scan(scan_id):
             subnet = scan.cfg.subnet
             port_list = scan.cfg.port_list
-            parallelism = scan.cfg.t_multiplier
 
         else:
             log.debug(f'Redirecting, scan {scan_id} doesnt exist in memory')
@@ -30,7 +28,6 @@ def index():
         'main.html',
         subnet=subnet,
         port_list=port_list,
-        parallelism=parallelism,
         alternate_subnets=subnets
     )
 

--- a/lanscape/ui/static/css/style.css
+++ b/lanscape/ui/static/css/style.css
@@ -390,20 +390,6 @@ input[type="range"] {
     margin: 5px 0;
 }
 
-input[type="range"]::-webkit-slider-thumb,
-input[type="range"]::-moz-range-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background: var(--primary-accent);
-    cursor: pointer;
-}
-#parallelism-value span {
-    color: var(--text-danger-color);
-    font-weight: 500;
-}
 .port-list-wrapper {
     position: relative;
     display: inline-block;
@@ -461,6 +447,20 @@ input[type="range"]::-moz-range-thumb {
 .port-list-dropdown div:hover {
     background-color: var(--secondary-accent);
     color: var(--text-color);
+}
+
+.config-option {
+    background-color: var(--primary-bg-accent);
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    cursor: pointer;
+    text-align: center;
+    margin: 0 5px;
+}
+
+.config-option.active {
+    border-color: var(--primary-accent);
+    box-shadow: 0 0 5px var(--primary-accent);
 }
 
 .text-secondary {

--- a/lanscape/ui/static/js/main.js
+++ b/lanscape/ui/static/js/main.js
@@ -3,16 +3,6 @@
 $(document).ready(function() {
     // Load port lists into the dropdown
     getPortLists();
-    
-    $('#parallelism').on('input', function() {
-        const val = $('#parallelism').val();
-        let ans = val;
-
-        if (parseFloat(val) > 1) {
-            ans += ' <span>Warning: Increased parallelism may have inaccurate results<span>'
-        }
-        $('#parallelism-value').html(ans);
-    });
     const scanId = getActiveScanId();
     if (scanId) {
         showScan(scanId);
@@ -46,15 +36,12 @@ $(document).ready(function() {
 });
 
 function submitNewScan() {
-    const formData = {
-        subnet: $('#subnet').val(),
-        port_list: $('#port-list').text(),
-        parallelism: $('#parallelism').val()
-    };
+    const config = getScanConfig();
+    config.subnet = $('#subnet').val();
     $.ajax('/api/scan', {
-        data : JSON.stringify(formData),
-        contentType : 'application/json',
-        type : 'POST',
+        data: JSON.stringify(config),
+        contentType: 'application/json',
+        type: 'POST',
         success: function(response) {
             if (response.status === 'running') {
                 showScan(response.scan_id);

--- a/lanscape/ui/static/js/scan-config.js
+++ b/lanscape/ui/static/js/scan-config.js
@@ -1,13 +1,16 @@
 let defaultScanConfigs = {};
+let activeConfigName = 'balanced';
 
 $(document).ready(function() {
     getScanDefaults(function() {
         setScanConfig('balanced');
     });
+    $('#t_cnt_port_scan, #t_cnt_port_test, #t_multiplier').on('input', updatePortTotals);
+    $('#ping_attempts, #ping_ping_count').on('input', updatePingTotals);
 });
 
 function getScanDefaults(callback=null) {
-    $.getJSON(`/api/tools/config/defaults`,(data) => {
+    $.getJSON('/api/tools/config/defaults', (data) => {
         defaultScanConfigs = data;
         if (callback) callback();
     });
@@ -15,11 +18,73 @@ function getScanDefaults(callback=null) {
 
 function setScanConfig(configName) {
     const config = defaultScanConfigs[configName];
-    console.log(`Setting scan config to ${configName}`, config);
-    if (config) {
-        $('#scan-config').val(JSON.stringify(config, null, 2));
-        $('#port-list').val(config.port_list),
-        $('#parallelism').val(config.port_list)
-        // more to come
-    }
+    if (!config) return;
+    activeConfigName = configName;
+
+    // highlight selected preset
+    $('.config-option').removeClass('active');
+    $(`#config-${configName}`).addClass('active');
+
+    // basic settings
+    $('#port-list').text(config.port_list);
+    $('#t_multiplier').val(config.t_multiplier);
+    $('#t_cnt_port_scan').val(config.t_cnt_port_scan);
+    $('#t_cnt_port_test').val(config.t_cnt_port_test);
+    $('#t_cnt_isalive').val(config.t_cnt_isalive);
+    $('#task_scan_ports').prop('checked', config.task_scan_ports);
+    $('#task_scan_port_services').prop('checked', config.task_scan_port_services);
+    $('#lookup_type').val(config.lookup_type);
+
+    // ping config
+    $('#ping_attempts').val(config.ping_config.attempts);
+    $('#ping_ping_count').val(config.ping_config.ping_count);
+    $('#ping_retry_delay').val(config.ping_config.retry_delay);
+    $('#ping_timeout').val(config.ping_config.timeout);
+
+    // arp config
+    $('#arp_attempts').val(config.arp_config.attempts);
+    $('#arp_timeout').val(config.arp_config.timeout);
+
+    updatePortTotals();
+    updatePingTotals();
 }
+
+function getScanConfig() {
+    return {
+        port_list: $('#port-list').text(),
+        t_multiplier: parseFloat($('#t_multiplier').val()),
+        t_cnt_port_scan: parseInt($('#t_cnt_port_scan').val()),
+        t_cnt_port_test: parseInt($('#t_cnt_port_test').val()),
+        t_cnt_isalive: parseInt($('#t_cnt_isalive').val()),
+        task_scan_ports: $('#task_scan_ports').is(':checked'),
+        task_scan_port_services: $('#task_scan_port_services').is(':checked'),
+        lookup_type: $('#lookup_type').val(),
+        ping_config: {
+            attempts: parseInt($('#ping_attempts').val()),
+            ping_count: parseInt($('#ping_ping_count').val()),
+            retry_delay: parseFloat($('#ping_retry_delay').val()),
+            timeout: parseFloat($('#ping_timeout').val())
+        },
+        arp_config: {
+            attempts: parseInt($('#arp_attempts').val()),
+            timeout: parseFloat($('#arp_timeout').val())
+        }
+    };
+}
+
+function updatePortTotals() {
+    const scan = parseInt($('#t_cnt_port_scan').val()) || 0;
+    const test = parseInt($('#t_cnt_port_test').val()) || 0;
+    const mult = parseFloat($('#t_multiplier').val()) || 0;
+    $('#total-port-tests').text(scan * test * mult);
+}
+
+function updatePingTotals() {
+    const attempts = parseInt($('#ping_attempts').val()) || 0;
+    const count = parseInt($('#ping_ping_count').val()) || 0;
+    $('#total-ping-attempts').text(attempts * count);
+}
+
+// expose functions globally
+window.setScanConfig = setScanConfig;
+window.getScanConfig = getScanConfig;

--- a/lanscape/ui/templates/main.html
+++ b/lanscape/ui/templates/main.html
@@ -56,20 +56,29 @@
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <div class="d-flex justify-content-around mb-2">
-            <div class="config-option p-3" onclick="setScanConfig('fast')">
-                <h5>Fast</h5>
-                <p>Fast scan, Low accuracy</p>
+        <div class="d-flex gap-2 mb-3">
+            <div class="config-option p-3 flex-fill" id="config-fast" data-config="fast" onclick="setScanConfig('fast')">
+                <h5 class="mb-1 d-flex align-items-center justify-content-center">
+                    <span class="material-symbols-outlined me-1">bolt</span>Fast
+                </h5>
+                <p class="mb-0">Fast scan, Low accuracy</p>
             </div>
-            <div class="config-option p-3" onclick="setScanConfig('balanced')">
-                <h5>Balanced</h5>
-                <p>Balanced scan, Moderate accuracy</p>
+            <div class="config-option p-3 flex-fill" id="config-balanced" data-config="balanced" onclick="setScanConfig('balanced')">
+                <h5 class="mb-1 d-flex align-items-center justify-content-center">
+                    <span class="material-symbols-outlined me-1">balance</span>Balanced
+                </h5>
+                <p class="mb-0">Balanced scan, Moderate accuracy</p>
             </div>
-            <div class="config-option p-3" onclick="setScanConfig('accurate')">
-                <h5>Accurate</h5>
-                <p>Thorough scan, High accuracy</p>
+            <div class="config-option p-3 flex-fill" id="config-accurate" data-config="accurate" onclick="setScanConfig('accurate')">
+                <h5 class="mb-1 d-flex align-items-center justify-content-center">
+                    <span class="material-symbols-outlined me-1">target</span>Accurate
+                </h5>
+                <p class="mb-0">Thorough scan, High accuracy</p>
             </div>
         </div>
+
+        <hr>
+
         <div class="form-group mt-2">
             <label for="port_list">Port List:</label>
             <div class="port-list-wrapper">
@@ -79,9 +88,102 @@
         </div>
 
         <div class="form-group mt-2">
-            <label for="parallelism">Parallelism:</label>
-            <input type="range" id="parallelism" name="parallelism" min="0.25" max="3" step="0.05" value="{{parallelism}}">
-            <output id="parallelism-value">{{parallelism}}</output>
+            <label for="lookup_type">Lookup Type:</label>
+            <div class="port-list-wrapper">
+                <select id="lookup_type" class="port-list">
+                    <option value="both">ARP + Ping</option>
+                    <option value="arp">ARP Only</option>
+                    <option value="ping">Ping Only</option>
+                </select>
+            </div>
+        </div>
+
+        <hr>
+
+        <div class="form-group mt-2">
+            <h6>Thread Settings</h6>
+            <div class="row">
+                <div class="col">
+                    <label for="t_cnt_port_scan">Port Scan Threads</label>
+                    <input type="number" id="t_cnt_port_scan" class="form-control">
+                </div>
+                <div class="col">
+                    <label for="t_cnt_port_test">Port Test Threads</label>
+                    <input type="number" id="t_cnt_port_test" class="form-control">
+                </div>
+            </div>
+            <div class="row mt-2">
+                <div class="col">
+                    <label for="t_multiplier">Thread Multiplier</label>
+                    <input type="number" step="0.1" id="t_multiplier" class="form-control">
+                </div>
+                <div class="col">
+                    <label for="t_cnt_isalive">Is Alive Threads</label>
+                    <input type="number" id="t_cnt_isalive" class="form-control">
+                </div>
+            </div>
+            <div class="mt-2 small">
+                Total concurrent port tests: <span id="total-port-tests"></span>
+            </div>
+        </div>
+
+        <hr>
+
+        <div class="form-group mt-2">
+            <h6>Tasks</h6>
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="task_scan_ports">
+                <label class="form-check-label" for="task_scan_ports">Scan Ports</label>
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="task_scan_port_services">
+                <label class="form-check-label" for="task_scan_port_services">Scan Port Services</label>
+            </div>
+        </div>
+
+        <hr>
+
+        <div class="form-group mt-2">
+            <h6>Ping Settings</h6>
+            <div class="row">
+                <div class="col">
+                    <label for="ping_attempts" class="form-label">Ping Attempts</label>
+                    <input type="number" id="ping_attempts" class="form-control">
+                </div>
+                <div class="col">
+                    <label for="ping_ping_count" class="form-label">Ping Count</label>
+                    <input type="number" id="ping_ping_count" class="form-control">
+                </div>
+            </div>
+            <div class="mt-2 small">
+                Total ping attempts: <span id="total-ping-attempts"></span>
+            </div>
+            <div class="row mt-2">
+                <div class="col">
+                    <label for="ping_timeout" class="form-label">Timeout</label>
+                    <input type="number" step="0.1" id="ping_timeout" class="form-control">
+                </div>
+                <div class="col">
+                    <label for="ping_retry_delay" class="form-label">Retry Delay</label>
+                    <input type="number" step="0.1" id="ping_retry_delay" class="form-control">
+                </div>
+            </div>
+        </div>
+
+        <hr>
+
+        <div class="form-group mt-2">
+            <h6>ARP Settings</h6>
+            <div class="row">
+                <div class="col">
+                    <label for="arp_attempts" class="form-label">Attempts</label>
+                    <input type="number" id="arp_attempts" class="form-control">
+                </div>
+                <div class="col">
+                    <label for="arp_timeout" class="form-label">Timeout</label>
+                    <input type="number" step="0.1" id="arp_timeout" class="form-control">
+                </div>
+            </div>
         </div>
       </div>
       <div class="modal-footer border-secondary">

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -154,8 +154,7 @@ class ApiTestCase(unittest.TestCase):
         # Create a new scan
         new_scan = {
             'subnet': right_size_subnet(get_network_subnet()),
-            'port_list': 'small',
-            'parallelism': 1
+            'port_list': 'small'
         }
         response = self.app.post('/api/scan', json=new_scan)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- expose all ScanConfig options in Advanced Settings modal
- manage presets and config reading in new `scan-config.js`
- submit complete scan config to backend

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f8c85dd8832aa23f0137222483d4