### PR TITLE
1.3.6 - Add scan table filter coverage to API test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -163,6 +163,7 @@ class ApiTestCase(unittest.TestCase):
             f'/?scan_id={scanid}',
             f'/scan/{scanid}/overview',
             f'/scan/{scanid}/table',
+            f'/scan/{scanid}/table?filter=test',
             f'/export/{scanid}'
         ]
         for uri in uris:


### PR DESCRIPTION
## Summary
- add coverage for accessing the scan table with a filter query as part of the existing scan UI checks

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d0966f2a08832ab4859f4a77bdbcda