### PR TITLE
1.4.0 - Standardize the design for methods that need to run only once

### DIFF
--- a/lanscape/libraries/decorators.py
+++ b/lanscape/libraries/decorators.py
@@ -1,7 +1,5 @@
 
-"""
-Decorators and job tracking utilities for Lanscape.
-"""
+"""Decorators and job tracking utilities for Lanscape."""
 
 from time import time
 from dataclasses import dataclass, field
@@ -10,7 +8,35 @@ from collections import defaultdict
 import inspect
 import functools
 import concurrent.futures
+import logging
 from tabulate import tabulate
+
+
+log = logging.getLogger(__name__)
+
+
+def run_once(func):
+    """Ensure a function executes only once and cache the result."""
+
+    cache_attr = "_run_once_cache"
+    ran_attr = "_run_once_ran"
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if getattr(wrapper, ran_attr, False):
+            return getattr(wrapper, cache_attr)
+
+        start = time()
+        result = func(*args, **kwargs)
+        elapsed = time() - start
+
+        setattr(wrapper, cache_attr, result)
+        setattr(wrapper, ran_attr, True)
+
+        log.debug("run_once executed %s in %.4fs", func.__qualname__, elapsed)
+        return result
+
+    return wrapper
 
 
 @dataclass

--- a/lanscape/libraries/version_manager.py
+++ b/lanscape/libraries/version_manager.py
@@ -11,8 +11,8 @@ from random import randint
 
 import requests
 
-from libraries.app_scope import is_local_run
-from libraries.decorators import run_once
+from lanscape.libraries.app_scope import is_local_run
+from lanscape.libraries.decorators import run_once
 
 log = logging.getLogger('VersionManager')
 

--- a/lanscape/libraries/version_manager.py
+++ b/lanscape/libraries/version_manager.py
@@ -11,8 +11,8 @@ from random import randint
 
 import requests
 
-from .app_scope import is_local_run
-from .decorators import run_once
+from libraries.app_scope import is_local_run
+from libraries.decorators import run_once
 
 log = logging.getLogger('VersionManager')
 
@@ -63,7 +63,7 @@ def lookup_latest_version(package=PACKAGE):
     no_cache = f'?cachebust={randint(0, 6969)}'
     url = f"https://pypi.org/pypi/{package}/json{no_cache}"
     try:
-        response = requests.get(url, timeout=5)
+        response = requests.get(url, timeout=3)
         response.raise_for_status()  # Raise an exception for HTTP errors
         latest_version = response.json()['info']['version']
         log.debug(f'Latest pypi version: {latest_version}')

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -27,4 +27,3 @@ def test_run_once_caches_result_and_logs_once(caplog):
     messages = [record.message for record in caplog.records]
     assert any("run_once executed" in record and "sample_function" in record for record in messages)
     assert sum("run_once executed" in record for record in messages) == 1
-

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,30 @@
+"""Tests for helper decorators used throughout the project."""
+
+import logging
+
+from lanscape.libraries.decorators import run_once
+
+
+def test_run_once_caches_result_and_logs_once(caplog):
+    """run_once should execute only one time and cache the return value."""
+
+    caplog.set_level(logging.DEBUG)
+
+    call_count = {"count": 0}
+
+    @run_once
+    def sample_function(value):
+        call_count["count"] += 1
+        return value * 2
+
+    first = sample_function(3)
+    second = sample_function(5)
+
+    assert first == 6
+    assert second == 6
+    assert call_count["count"] == 1
+
+    messages = [record.message for record in caplog.records]
+    assert any("run_once executed" in record and "sample_function" in record for record in messages)
+    assert sum("run_once executed" in record for record in messages) == 1
+


### PR DESCRIPTION
## Pull Request Overview

- Implements comprehensive test for the `run_once` decorator functionality
- Refactors existing code to utilize the new decorator instead of manual caching patterns
- Removes redundant singleton classes and global variables in favor of decorator-based caching

| File | Description |
| ---- | ----------- |
| tests/test_decorators.py | New test file verifying `run_once` decorator caches results and logs execution once |
| lanscape/libraries/decorators.py | Adds the `run_once` decorator implementation with logging and caching functionality |
| lanscape/libraries/version_manager.py | Refactored to use `run_once` decorator, removing global `LATEST_VERSION` variable |
| lanscape/libraries/net_tools.py | Replaced `ArpSupportChecker` singleton class with `run_once` decorated function |
