### PR TITLE
Refactor workflows to share reusable PyPI publish job

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,54 +5,11 @@ on:
     tags:
       - 'releases/*'
       - 'pre-releases/*'
-    
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install build twine
-          python -m pip install -r requirements.txt
-          
-      - name: Clean dist directory
-        run: |
-          rm -rf dist
-          rm -rf ./**/*.egg-info
-
-      - name: Extract tag version
-        id: get_tag
-        run: |
-          TAG_VERSION=${GITHUB_REF#refs/tags/}
-          TAG_VERSION=${TAG_VERSION##*/}
-          echo "tag_version=$TAG_VERSION" >> $GITHUB_ENV
-
-      - name: Update version in pyproject.toml
-        run: |
-          sed -i 's/^version = ".*"/version = "'"${{ env.tag_version }}"'"/' pyproject.toml
-
-      - name: Build package
-        run: |
-          python -m build
-
-      - name: Check package
-        run: |
-          python -m twine check dist/*
-
-      - name: Upload to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          TWINE_REPOSITORY: pypi
-        run: |
-          python -m twine upload --repository pypi dist/*
-
+  publish:
+    uses: ./.github/workflows/pypi-publish.yml
+    with:
+      branch: ${{ github.ref_name }}
+      version: ${{ replace(replace(github.ref_name, 'releases/', ''), 'pre-releases/', '') }}
+    secrets: inherit

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,59 @@
+name: Reusable PyPI Publish
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "Branch or tag to checkout before publishing"
+        required: true
+        type: string
+      version:
+        description: "Version number to apply to the package"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+          python -m pip install -r requirements.txt
+
+      - name: Clean dist directory
+        run: |
+          rm -rf dist
+          rm -rf ./**/*.egg-info
+
+      - name: Update version in pyproject.toml
+        run: |
+          VERSION='${{ inputs.version }}'
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
+
+      - name: Build package
+        run: |
+          python -m build
+
+      - name: Check package
+        run: |
+          python -m twine check dist/*
+
+      - name: Upload to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          TWINE_REPOSITORY: pypi
+        run: |
+          python -m twine upload --repository pypi dist/*

--- a/.github/workflows/tag-on-main-push.yml
+++ b/.github/workflows/tag-on-main-push.yml
@@ -5,40 +5,45 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   tag:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract_version.outputs.version }}
+      tag_name: ${{ steps.create_tag.outputs.tag_name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Get the latest commit message
-        id: get_commit
+      - name: Extract version from commit message
+        id: extract_version
         run: |
-            echo "COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -n1)" >> $GITHUB_ENV
-
-      - name: Validate commit message
-        id: validate
-        run: |
-          COMMIT_MSG="${{ env.COMMIT_MESSAGE }}"
-          # Extract the version part (before the first space)
+          COMMIT_MSG=$(git log -1 --pretty=%B | head -n1)
           VERSION_PART=$(echo "$COMMIT_MSG" | cut -d' ' -f1)
-          # Check if it has two dots and starts with a digit
           if echo "$VERSION_PART" | grep -q '^[0-9]\+\.[0-9]\+\.[0-9]\+$'; then
-            echo "VALID=true" >> $GITHUB_ENV
-            MAJOR=$(echo "$VERSION_PART" | cut -d. -f1)
-            MINOR=$(echo "$VERSION_PART" | cut -d. -f2)
-            MINISCULE=$(echo "$VERSION_PART" | cut -d. -f3)
-            echo "MAJOR=$MAJOR" >> $GITHUB_ENV
-            echo "MINOR=$MINOR" >> $GITHUB_ENV
-            echo "MINISCULE=$MINISCULE" >> $GITHUB_ENV
+            echo "version=$VERSION_PART" >> "$GITHUB_OUTPUT"
           else
-            echo "VALID=false" >> $GITHUB_ENV
+            echo "Commit message does not start with a semantic version. Skipping tag creation."
           fi
 
       - name: Create tag
-        if: ${{ env.VALID == 'true' }}
+        if: ${{ steps.extract_version.outputs.version != '' }}
+        id: create_tag
         run: |
-          TAG_NAME="releases/${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.MINISCULE }}"
-          git tag $TAG_NAME
-          git push origin $TAG_NAME
+          VERSION="${{ steps.extract_version.outputs.version }}"
+          TAG_NAME="releases/${VERSION}"
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: tag
+    if: ${{ needs.tag.outputs.version != '' }}
+    uses: ./.github/workflows/pypi-publish.yml
+    with:
+      branch: ${{ github.ref_name }}
+      version: ${{ needs.tag.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add a reusable PyPI publish workflow that accepts a branch/tag and version inputs
- update the main-branch tagging workflow to expose the commit version, push the release tag, and call the reusable publish workflow
- simplify the tag-triggered publish workflow to reuse the shared PyPI publish job

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d705871954832a85ae67418178474a