### PR TITLE
Demo - With agent instructions

### DIFF
--- a/.github/workflows/chore-wiki-sync.yml
+++ b/.github/workflows/chore-wiki-sync.yml
@@ -57,6 +57,9 @@ jobs:
           # Models
           FILE_MAP["$DOCS/models/overview.md"]="Models"
 
+          # DHCP Listener
+          FILE_MAP["$DOCS/dhcp-listener.md"]="DHCP-Listener"
+
           # Build reverse map: relative link target -> wiki page name
           # This handles all the cross-references between docs
           declare -A LINK_MAP
@@ -73,6 +76,7 @@ jobs:
           LINK_MAP["net-tools.md"]="net_tools"
           LINK_MAP["overview.md"]="Library-Overview"
           LINK_MAP["websocket-server.md"]="WebSocket-Server"
+          LINK_MAP["dhcp-listener.md"]="DHCP-Listener"
 
           # Also handle relative links from subdirectories (../ prefixed)
           LINK_MAP["../config/scan-config.md"]="ScanConfig"
@@ -87,6 +91,7 @@ jobs:
           LINK_MAP["../port-manager.md"]="PortManager"
           LINK_MAP["../net-tools.md"]="net_tools"
           LINK_MAP["../websocket-server.md"]="WebSocket-Server"
+          LINK_MAP["../dhcp-listener.md"]="DHCP-Listener"
 
           # Same-directory links (no path prefix)
           LINK_MAP["scan-manager.md"]="ScanManager"
@@ -161,6 +166,7 @@ jobs:
           | **[PortManager](PortManager)** | CRUD operations for port lists |
           | **[net_tools](net_tools)** | Subnet detection, ARP support, and network helpers |
           | **[WebSocket Server](WebSocket-Server)** | Real-time WebSocket API — protocol, actions, events |
+          | **[DHCP Listener](DHCP-Listener)** | Passively capture DHCP lease events in real time |
 
           ---
           *Auto-synced from [`docs/library`](https://github.com/mdennis281/LANscape/tree/main/docs/library)*

--- a/docs/library/dhcp-listener.md
+++ b/docs/library/dhcp-listener.md
@@ -1,0 +1,286 @@
+# DhcpListener
+
+`lanscape.DhcpListener`
+
+Passively captures DHCP traffic on the LAN and surfaces fully-parsed lease events — DISCOVERs, REQUESTs, OFFERs, ACKs, and more — via a callback interface.
+
+Useful for:
+- Watching new devices join the network in real time
+- Troubleshooting DHCP failures (e.g. DISCOVER with no ACK)
+- Auditing vendor class / hostname data sent by clients
+- Monitoring which subnets are actively requesting leases
+
+> **Privilege requirement:** Capturing on UDP ports 67/68 typically requires root / Administrator privileges. On Linux you can use `sudo`, on Windows run the process as Administrator.
+
+## Import
+
+```python
+from lanscape import DhcpListener, DhcpListenerConfig, DhcpLeaseEvent, DhcpMessageType
+```
+
+---
+
+## Quick Start
+
+```python
+from lanscape import DhcpListener, DhcpListenerConfig, DhcpMessageType
+
+config = DhcpListenerConfig(
+    subnet_filter=["192.168.1.0/24"],
+    message_types=[DhcpMessageType.DISCOVER, DhcpMessageType.REQUEST],
+)
+
+def on_event(event):
+    print(f"[{event.message_type.name}] {event.client_mac} → {event.effective_ip}")
+    if event.hostname:
+        print(f"  hostname : {event.hostname}")
+    if event.vendor_class:
+        print(f"  vendor   : {event.vendor_class}")
+
+with DhcpListener(config, on_event=on_event):
+    input("Listening for DHCP… press Enter to stop\n")
+```
+
+---
+
+## DhcpListenerConfig
+
+Configuration model for `DhcpListener`.
+
+```python
+from lanscape import DhcpListenerConfig, DhcpMessageType
+
+config = DhcpListenerConfig(
+    subnet_filter=["192.168.1.0/24", "10.0.0.0/8"],
+    message_types=[DhcpMessageType.DISCOVER, DhcpMessageType.REQUEST],
+    include_server_messages=False,
+    interface="eth0",
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `subnet_filter` | `List[str] \| None` | `None` | CIDR subnets to filter on. Only events where the client IP falls within one of these subnets are emitted. `None` = no filter (all events pass). |
+| `message_types` | `List[DhcpMessageType] \| None` | `None` | Restrict to these message types. `None` captures all types. |
+| `include_server_messages` | `bool` | `True` | When `False`, OFFER / ACK / NAK messages from the DHCP server are suppressed. |
+| `interface` | `str \| None` | `None` | Network interface to listen on. `None` listens on all interfaces. |
+
+---
+
+## DhcpListener
+
+### Constructor
+
+```python
+listener = DhcpListener(config: DhcpListenerConfig, on_event: Callable[[DhcpLeaseEvent], None])
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `config` | `DhcpListenerConfig` | Listener configuration |
+| `on_event` | `Callable[[DhcpLeaseEvent], None]` | Callback invoked for each matching packet. Called from the sniffer thread — keep it fast or hand off to a queue. |
+
+### Methods
+
+#### `start() -> None`
+
+Start the background sniffer. Raises `RuntimeError` if already running.
+
+#### `stop() -> None`
+
+Stop the sniffer and clean up resources. Safe to call when not running.
+
+#### `is_running -> bool`
+
+`True` while the sniffer thread is active.
+
+### Context Manager
+
+`DhcpListener` supports the context manager protocol:
+
+```python
+with DhcpListener(config, on_event=handler) as listener:
+    # listener is running here
+    time.sleep(60)
+# listener is stopped automatically
+```
+
+---
+
+## DhcpLeaseEvent
+
+Pydantic model representing a single parsed DHCP packet. All optional fields are `None` when absent from the packet.
+
+### Client identification
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `client_mac` | `str` | Client hardware (MAC) address from BOOTP `chaddr` |
+| `client_ip` | `str \| None` | Client IP (`ciaddr`) — non-zero only when client already has a lease |
+| `client_identifier` | `str \| None` | Option 61 — often MAC (formatted `aa:bb:cc:dd:ee:ff`) or UUID string |
+
+### IP negotiation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `requested_ip` | `str \| None` | Option 50 — IP the client is requesting |
+| `offered_ip` | `str \| None` | `yiaddr` — IP offered or assigned by the server |
+| `server_ip` | `str \| None` | `siaddr` — next-server IP from BOOTP header |
+| `server_identifier` | `str \| None` | Option 54 — DHCP server IP |
+
+### Client-supplied options
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `hostname` | `str \| None` | Option 12 — client-supplied hostname |
+| `fqdn` | `str \| None` | Option 81 (RFC 4702) — fully-qualified domain name |
+| `vendor_class` | `str \| None` | Option 60 — vendor class identifier (e.g. `"MSFT 5.0"`, `"android-dhcp-13"`) |
+| `user_class` | `str \| None` | Option 77 — user class information |
+| `requested_options` | `List[int] \| None` | Option 55 — list of option codes the client wants in the response |
+
+### Server-supplied lease parameters
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `subnet_mask` | `str \| None` | Option 1 — offered subnet mask |
+| `router` | `str \| None` | Option 3 — default gateway |
+| `dns_servers` | `List[str] \| None` | Option 6 — DNS server list |
+| `lease_time` | `int \| None` | Option 51 — lease duration in seconds |
+| `renewal_time` | `int \| None` | Option 58 — T1 renewal time in seconds |
+| `rebinding_time` | `int \| None` | Option 59 — T2 rebinding time in seconds |
+
+### Raw / transport
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `unknown_options` | `dict` | Code → `repr(value)` for any DHCP options not explicitly decoded |
+| `src_ip` | `str \| None` | IP-layer source address of the captured packet |
+| `dst_ip` | `str \| None` | IP-layer destination address |
+| `interface` | `str \| None` | Network interface the packet was captured on |
+| `timestamp` | `datetime` | UTC capture timestamp |
+| `message_type` | `DhcpMessageType \| None` | Option 53 — DHCP message type |
+
+### Computed properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `effective_ip` | `str \| None` | Best available client IP: `requested_ip` → `offered_ip` → `client_ip` |
+| `is_client_message` | `bool` | `True` for DISCOVER / REQUEST / DECLINE / RELEASE / INFORM |
+| `is_server_message` | `bool` | `True` for OFFER / ACK / NAK |
+
+---
+
+## DhcpMessageType
+
+`IntEnum` with all 8 DHCP message types defined in RFC 2131.
+
+```python
+from lanscape import DhcpMessageType
+```
+
+| Value | Name | Direction | Description |
+|-------|------|-----------|-------------|
+| `1` | `DISCOVER` | Client → Server | Client broadcasts to locate servers |
+| `2` | `OFFER` | Server → Client | Server offers an IP address |
+| `3` | `REQUEST` | Client → Server | Client requests offered or previously assigned address |
+| `4` | `DECLINE` | Client → Server | Client declines the offered address (conflict) |
+| `5` | `ACK` | Server → Client | Server confirms the lease |
+| `6` | `NAK` | Server → Client | Server denies the request |
+| `7` | `RELEASE` | Client → Server | Client releases its lease |
+| `8` | `INFORM` | Client → Server | Client already has IP, requests other config options |
+
+```python
+DhcpMessageType.from_int(5)   # → DhcpMessageType.ACK
+DhcpMessageType.from_int(99)  # → None  (unknown type, no exception)
+```
+
+---
+
+## Troubleshooting Examples
+
+### Log all DHCP activity to stdout
+
+```python
+import json
+from lanscape import DhcpListener, DhcpListenerConfig
+
+with DhcpListener(DhcpListenerConfig(), on_event=lambda e: print(e.model_dump_json(indent=2))):
+    input("Press Enter to stop\n")
+```
+
+### Queue events for multi-threaded processing
+
+```python
+import queue
+import threading
+from lanscape import DhcpListener, DhcpListenerConfig
+
+events: queue.Queue = queue.Queue()
+
+def worker():
+    while True:
+        event = events.get()
+        if event is None:
+            break
+        print(f"[{event.message_type.name}] {event.client_mac} → {event.effective_ip}")
+
+t = threading.Thread(target=worker, daemon=True)
+t.start()
+
+with DhcpListener(DhcpListenerConfig(), on_event=events.put):
+    input("Press Enter to stop\n")
+
+events.put(None)
+t.join()
+```
+
+### Watch for new devices on a specific subnet
+
+```python
+from lanscape import DhcpListener, DhcpListenerConfig, DhcpMessageType
+
+config = DhcpListenerConfig(
+    subnet_filter=["192.168.1.0/24"],
+    message_types=[DhcpMessageType.DISCOVER],
+    include_server_messages=False,
+)
+
+def on_discover(event):
+    print(f"New device looking for lease: {event.client_mac}")
+    print(f"  Hostname      : {event.hostname or '(not set)'}")
+    print(f"  Vendor class  : {event.vendor_class or '(not set)'}")
+    print(f"  Requested IP  : {event.requested_ip or '(any)'}")
+
+with DhcpListener(config, on_event=on_discover):
+    input("Press Enter to stop\n")
+```
+
+### Correlate with a running scan
+
+```python
+from lanscape import DhcpListener, DhcpListenerConfig, DhcpMessageType, ScanManager, ScanConfig
+
+sm = ScanManager()
+config = ScanConfig(subnet="192.168.1.0/24", port_list="small")
+scan = sm.new_scan(config)
+
+def on_dhcp(event):
+    if event.message_type == DhcpMessageType.ACK and event.offered_ip:
+        print(f"New lease granted: {event.offered_ip} → {event.client_mac}")
+
+dhcp_cfg = DhcpListenerConfig(subnet_filter=["192.168.1.0/24"])
+with DhcpListener(dhcp_cfg, on_event=on_dhcp):
+    sm.wait_until_complete(scan.uid)
+
+results = scan.results.to_results()
+print(f"Scan complete — {len(results.devices)} devices found")
+```
+
+---
+
+## Notes
+
+- `DhcpListener` uses [scapy](https://scapy.net/)'s `AsyncSniffer` with a BPF filter `udp and (port 67 or port 68)`. scapy is bundled as a dependency of LANscape.
+- The `on_event` callback runs on the sniffer thread. For non-trivial processing, dispatch to a `queue.Queue` to avoid blocking packet capture.
+- On Windows, scapy requires [Npcap](https://npcap.com/) or WinPcap to be installed.
+- On Linux, raw socket capture typically requires `CAP_NET_RAW` or running as root.

--- a/docs/library/overview.md
+++ b/docs/library/overview.md
@@ -52,6 +52,7 @@ for device in results.devices:
 | [Models](models/overview.md) | Pydantic models for devices, scan results, and stage progress |
 | [`net_tools`](net-tools.md) | Network utility functions (subnet detection, ARP support check, hostname resolution) |
 | [WebSocket Server](websocket-server.md) | Real-time WebSocket API, HTTP discovery endpoint, mDNS, and CLI arguments |
+| [`DhcpListener`](dhcp-listener.md) | Passive DHCP listener — capture and filter lease events in real time |
 
 ## Architecture Overview
 

--- a/lanscape/__init__.py
+++ b/lanscape/__init__.py
@@ -124,3 +124,11 @@ from lanscape.core.version_manager import (
     is_update_available,
     lookup_latest_version
 )
+
+# DHCP lease request listener
+from lanscape.core.dhcp_listener import (
+    DhcpListener,
+    DhcpListenerConfig,
+    DhcpLeaseEvent,
+    DhcpMessageType,
+)

--- a/lanscape/core/dhcp_listener.py
+++ b/lanscape/core/dhcp_listener.py
@@ -1,0 +1,568 @@
+"""DHCP lease request listener.
+
+Passively captures DHCP traffic on the LAN and surfaces fully-parsed
+lease events — DISCOVERs, REQUESTs, OFFERs, ACKs, and more — via a
+simple callback interface.
+
+Useful for:
+    - Watching new devices join the network in real time
+    - Troubleshooting DHCP failures (DISCOVER with no ACK, etc.)
+    - Auditing vendor class / hostname data sent by clients
+
+Usage::
+
+    from lanscape.core.dhcp_listener import DhcpListener, DhcpListenerConfig
+
+    config = DhcpListenerConfig(
+        subnet_filter=["192.168.1.0/24"],
+        message_types=[DhcpMessageType.DISCOVER, DhcpMessageType.REQUEST],
+    )
+
+    def on_event(event: DhcpLeaseEvent) -> None:
+        print(event.model_dump_json(indent=2))
+
+    listener = DhcpListener(config, on_event=on_event)
+    listener.start()
+    # ... later ...
+    listener.stop()
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import threading
+from datetime import datetime, timezone
+from enum import IntEnum
+from typing import Callable, List, Optional
+
+from pydantic import BaseModel, Field
+from scapy.layers.dhcp import BOOTP, DHCP
+from scapy.layers.inet import IP
+from scapy.sendrecv import AsyncSniffer
+
+log = logging.getLogger(__name__)
+
+
+# ─── Enums ────────────────────────────────────────────────────────
+
+class DhcpMessageType(IntEnum):
+    """DHCP message-type option values (RFC 2131)."""
+    DISCOVER = 1
+    OFFER    = 2
+    REQUEST  = 3
+    DECLINE  = 4
+    ACK      = 5
+    NAK      = 6
+    RELEASE  = 7
+    INFORM   = 8
+
+    @classmethod
+    def from_int(cls, value: int) -> Optional["DhcpMessageType"]:
+        """Return the enum member for *value*, or ``None`` if unknown."""
+        try:
+            return cls(value)
+        except ValueError:
+            return None
+
+
+# ─── Pydantic models ──────────────────────────────────────────────
+
+class DhcpLeaseEvent(BaseModel):
+    """Fully-parsed snapshot of a single DHCP packet.
+
+    All optional fields are ``None`` when absent from the packet.
+    """
+
+    # ── DHCP message classification ──
+    message_type: Optional[DhcpMessageType] = Field(
+        default=None,
+        description="DHCP message type (option 53)"
+    )
+
+    # ── Client identification ──
+    client_mac: str = Field(
+        description="Client hardware (MAC) address from BOOTP chaddr"
+    )
+    client_ip: Optional[str] = Field(
+        default=None,
+        description="Client IP address (ciaddr — non-zero only when client already has a lease)"
+    )
+    client_identifier: Optional[str] = Field(
+        default=None,
+        description="Client identifier from option 61 (often MAC or UUID)"
+    )
+
+    # ── IP negotiation ──
+    requested_ip: Optional[str] = Field(
+        default=None,
+        description="IP the client is requesting (option 50)"
+    )
+    offered_ip: Optional[str] = Field(
+        default=None,
+        description="IP offered or assigned by the server (yiaddr)"
+    )
+    server_ip: Optional[str] = Field(
+        default=None,
+        description="Next-server IP from BOOTP siaddr"
+    )
+    server_identifier: Optional[str] = Field(
+        default=None,
+        description="DHCP server identifier from option 54"
+    )
+
+    # ── Client-supplied options ──
+    hostname: Optional[str] = Field(
+        default=None,
+        description="Client-supplied hostname (option 12)"
+    )
+    fqdn: Optional[str] = Field(
+        default=None,
+        description="Fully-qualified domain name from option 81"
+    )
+    vendor_class: Optional[str] = Field(
+        default=None,
+        description="Vendor class identifier (option 60) — e.g. 'MSFT 5.0', 'android-dhcp-13'"
+    )
+    user_class: Optional[str] = Field(
+        default=None,
+        description="User class information (option 77)"
+    )
+    requested_options: Optional[List[int]] = Field(
+        default=None,
+        description="Parameter request list (option 55) — options the client wants in the response"
+    )
+
+    # ── Server-supplied lease parameters ──
+    subnet_mask: Optional[str] = Field(
+        default=None,
+        description="Offered subnet mask (option 1)"
+    )
+    router: Optional[str] = Field(
+        default=None,
+        description="Default gateway from option 3"
+    )
+    dns_servers: Optional[List[str]] = Field(
+        default=None,
+        description="DNS server list from option 6"
+    )
+    lease_time: Optional[int] = Field(
+        default=None,
+        description="Lease duration in seconds (option 51)"
+    )
+    renewal_time: Optional[int] = Field(
+        default=None,
+        description="T1 renewal time in seconds (option 58)"
+    )
+    rebinding_time: Optional[int] = Field(
+        default=None,
+        description="T2 rebinding time in seconds (option 59)"
+    )
+
+    # ── Raw extras ──
+    unknown_options: dict = Field(
+        default_factory=dict,
+        description="Option code → raw value for any options not explicitly decoded"
+    )
+
+    # ── Transport metadata ──
+    src_ip: Optional[str] = Field(
+        default=None,
+        description="IP-layer source address of the captured packet"
+    )
+    dst_ip: Optional[str] = Field(
+        default=None,
+        description="IP-layer destination address of the captured packet"
+    )
+    interface: Optional[str] = Field(
+        default=None,
+        description="Network interface the packet was captured on"
+    )
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="UTC timestamp of capture"
+    )
+
+    @property
+    def effective_ip(self) -> Optional[str]:
+        """Best available client IP: requested → offered → ciaddr."""
+        return self.requested_ip or self.offered_ip or self.client_ip
+
+    @property
+    def is_client_message(self) -> bool:
+        """True for messages initiated by the client.
+
+        Covers: DISCOVER, REQUEST, DECLINE, RELEASE, and INFORM.
+        """
+        client_types = {
+            DhcpMessageType.DISCOVER,
+            DhcpMessageType.REQUEST,
+            DhcpMessageType.DECLINE,
+            DhcpMessageType.RELEASE,
+            DhcpMessageType.INFORM,
+        }
+        return self.message_type in client_types
+
+    @property
+    def is_server_message(self) -> bool:
+        """True for messages initiated by the server (OFFER / ACK / NAK)."""
+        server_types = {DhcpMessageType.OFFER, DhcpMessageType.ACK, DhcpMessageType.NAK}
+        return self.message_type in server_types
+
+
+class DhcpListenerConfig(BaseModel):
+    """Configuration for :class:`DhcpListener`."""
+
+    subnet_filter: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Only emit events where the effective client IP falls within one of these subnets. "
+            "Accepts any notation accepted by ipaddress.ip_network (e.g. '192.168.1.0/24'). "
+            "``None`` means no filtering — all events are emitted."
+        )
+    )
+    message_types: Optional[List[DhcpMessageType]] = Field(
+        default=None,
+        description=(
+            "Restrict captured events to these message types. "
+            "``None`` captures all message types."
+        )
+    )
+    include_server_messages: bool = Field(
+        default=True,
+        description="When True, OFFER / ACK / NAK from DHCP servers are also emitted"
+    )
+    interface: Optional[str] = Field(
+        default=None,
+        description="Network interface to listen on. ``None`` listens on all interfaces"
+    )
+
+
+# ─── Option parser helpers ────────────────────────────────────────
+
+# Scapy DHCP option tuples use string keys for known options and
+# integer keys for unknown ones. This map translates known names
+# back to the canonical option number so we can handle them uniformly.
+
+_OPTION_NAME_TO_CODE: dict[str, int] = {
+    "subnet_mask": 1,
+    "router": 3,
+    "name_server": 6,
+    "hostname": 12,
+    "requested_addr": 50,
+    "lease_time": 51,
+    "message-type": 53,
+    "server_id": 54,
+    "param_req_list": 55,
+    "vendor_class_id": 60,
+    "client_id": 61,
+    "renewal_time": 58,
+    "rebinding_time": 59,
+    "FQDN": 81,
+    "user_class": 77,
+}
+
+
+def _decode_bytes(value: object) -> Optional[str]:
+    """Best-effort bytes → str; returns None for non-byte values."""
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode("utf-8", errors="replace").strip("\x00")
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _mac_from_bytes(raw: bytes) -> str:
+    """Format a 6-byte (or longer) bytes object as a MAC address string."""
+    return ":".join(f"{b:02x}" for b in raw[:6])
+
+
+def _parse_dhcp_options(options: list) -> dict:
+    """Flatten a scapy DHCP options list into a {code: value} dict."""
+    result: dict = {}
+    for item in options:
+        if not isinstance(item, (tuple, list)) or len(item) < 2:
+            continue
+        key, value = item[0], item[1]
+        if key in ("end", "pad"):
+            continue
+        code = _OPTION_NAME_TO_CODE.get(key, key) if isinstance(key, str) else key
+        result[code] = value
+    return result
+
+
+def _first_ip(value: object) -> Optional[str]:
+    """Return the first IP string from a single value or a list."""
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return str(value[0]) if value else None
+    return str(value)
+
+
+def _ip_list(value: object) -> Optional[List[str]]:
+    """Return a list of IP strings from a single value or a list."""
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return [str(v) for v in value]
+    return [str(value)]
+
+
+# ─── Subnet filter ────────────────────────────────────────────────
+
+def _build_subnet_networks(
+    subnet_filter: Optional[List[str]],
+) -> Optional[List[ipaddress.IPv4Network]]:
+    """Parse subnet strings into network objects. Returns None for no filter."""
+    if not subnet_filter:
+        return None
+    networks = []
+    for s in subnet_filter:
+        try:
+            networks.append(ipaddress.ip_network(s, strict=False))
+        except ValueError:
+            log.warning("DhcpListener: ignoring invalid subnet filter %r", s)
+    return networks or None
+
+
+def _ip_in_networks(ip: Optional[str], networks: Optional[List[ipaddress.IPv4Network]]) -> bool:
+    """Return True if *ip* is contained within any of *networks*, or if no filter is set."""
+    if networks is None:
+        return True
+    if ip is None:
+        return False
+    try:
+        addr = ipaddress.ip_address(ip)
+        return any(addr in net for net in networks)
+    except ValueError:
+        return False
+
+
+# ─── Core listener ────────────────────────────────────────────────
+
+class DhcpListener:
+    """Passive DHCP listener.
+
+    Captures DHCP packets on UDP ports 67/68 and calls *on_event* for
+    every packet that passes the configured filters.
+
+    The sniffer runs in a daemon thread — it will not prevent the
+    process from exiting.  Call :meth:`stop` to release resources cleanly.
+
+    Args:
+        config: Listener configuration (subnet filter, message-type filter, etc.)
+        on_event: Callable invoked with a :class:`DhcpLeaseEvent` for each
+            matching packet.  Invoked from the sniffer thread; keep it fast
+            or dispatch to a queue.
+    """
+
+    def __init__(
+        self,
+        config: DhcpListenerConfig,
+        on_event: Callable[[DhcpLeaseEvent], None],
+    ) -> None:
+        self._config = config
+        self._on_event = on_event
+        self._sniffer = None
+        self._thread: Optional[threading.Thread] = None
+        self._networks = _build_subnet_networks(config.subnet_filter)
+        self._running = False
+
+    # ── Public API ────────────────────────────────────────────────
+
+    @property
+    def is_running(self) -> bool:
+        """True while the sniffer thread is active."""
+        return self._running
+
+    def start(self) -> None:
+        """Start the background sniffer thread.
+
+        Raises:
+            RuntimeError: If the listener is already running.
+            ImportError: If scapy is not installed.
+        """
+        if self._running:
+            raise RuntimeError("DhcpListener is already running")
+
+        bpf_filter = "udp and (port 67 or port 68)"
+        kwargs: dict = {
+            "filter": bpf_filter,
+            "prn": self._handle_packet,
+            "store": False,
+        }
+        if self._config.interface:
+            kwargs["iface"] = self._config.interface
+
+        self._sniffer = AsyncSniffer(**kwargs)
+        self._sniffer.start()
+        self._running = True
+        log.info("DhcpListener started (interface=%s)", self._config.interface or "all")
+
+    def stop(self) -> None:
+        """Stop the sniffer and join the background thread."""
+        if not self._running or self._sniffer is None:
+            return
+        try:
+            self._sniffer.stop()
+        except Exception:  # pylint: disable=broad-except
+            log.debug("DhcpListener: error stopping sniffer", exc_info=True)
+        self._running = False
+        log.info("DhcpListener stopped")
+
+    def __enter__(self) -> "DhcpListener":
+        self.start()
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.stop()
+
+    # ── Internal ──────────────────────────────────────────────────
+
+    def _handle_packet(self, pkt) -> None:
+        """Scapy packet callback — parse, filter, and dispatch."""
+        try:
+            event = _parse_packet(pkt)
+            if event is None:
+                return
+            if self._passes_filters(event):
+                self._on_event(event)
+        except Exception:  # pylint: disable=broad-except
+            log.debug("DhcpListener: error parsing packet", exc_info=True)
+
+    def _passes_filters(self, event: DhcpLeaseEvent) -> bool:
+        """Return True if *event* matches all configured filters."""
+        # ── Server message opt-out ──
+        if not self._config.include_server_messages and event.is_server_message:
+            return False
+
+        # ── Message-type filter ──
+        if self._config.message_types is not None:
+            if event.message_type not in self._config.message_types:
+                return False
+
+        # ── Subnet filter ──
+        if self._networks is not None:
+            # For client messages, check requested or ciaddr.
+            # For server messages (OFFER/ACK), check offered_ip or server_id.
+            candidate_ips = [
+                event.requested_ip,
+                event.offered_ip,
+                event.client_ip,
+            ]
+            if not any(_ip_in_networks(ip, self._networks) for ip in candidate_ips):
+                return False
+
+        return True
+
+
+# ─── Option sub-decoders ─────────────────────────────────────────
+
+def _decode_client_identifier(opts: dict) -> Optional[str]:
+    """Decode DHCP option 61 (client identifier) to a string.
+
+    Type byte 0x01 → format remaining bytes as MAC address.
+    Otherwise decode the payload as UTF-8.
+    """
+    raw = opts.get(61)
+    if raw is None:
+        return None
+    if isinstance(raw, (bytes, bytearray)) and len(raw) > 1:
+        id_type, payload = raw[0], raw[1:]
+        if id_type == 1 and len(payload) >= 6:
+            return _mac_from_bytes(payload)
+        return payload.decode("utf-8", errors="replace")
+    return _decode_bytes(raw)
+
+
+def _decode_fqdn(opts: dict) -> Optional[str]:
+    """Decode DHCP option 81 (FQDN, RFC 4702).
+
+    The first 3 bytes are flags/RCODE/RCODE2 — the name starts at byte 4.
+    """
+    raw = opts.get(81)
+    if raw is None:
+        return None
+    if isinstance(raw, (bytes, bytearray)) and len(raw) > 3:
+        return raw[3:].decode("utf-8", errors="replace").strip("\x00.")
+    return _decode_bytes(raw)
+
+
+def _decode_requested_options(opts: dict) -> Optional[List[int]]:
+    """Decode DHCP option 55 (parameter request list) to a list of ints."""
+    param_req = opts.get(55)
+    if param_req is None:
+        return None
+    if isinstance(param_req, (list, tuple)):
+        return [int(x) for x in param_req]
+    if isinstance(param_req, (bytes, bytearray)):
+        return list(param_req)
+    return None
+
+
+def _extract_unknown_options(opts: dict) -> dict:
+    """Return option code → repr(value) for all unrecognised option codes."""
+    known = set(_OPTION_NAME_TO_CODE.values())
+    return {
+        code: repr(val)
+        for code, val in opts.items()
+        if isinstance(code, int) and code not in known
+    }
+
+
+# ─── Packet parser (module-level, testable standalone) ───────────
+
+def _parse_packet(pkt) -> Optional[DhcpLeaseEvent]:
+    """Parse a scapy packet into a :class:`DhcpLeaseEvent`.
+
+    Returns ``None`` if the packet does not contain a DHCP layer.
+    """
+    if DHCP not in pkt or BOOTP not in pkt:
+        return None
+
+    bootp = pkt[BOOTP]
+    opts = _parse_dhcp_options(getattr(pkt[DHCP], "options", []))
+
+    # ── Client MAC ──
+    client_mac = _mac_from_bytes(bytes(bootp.chaddr))
+
+    # ── IP fields from BOOTP fixed header ──
+    client_ip  = str(bootp.ciaddr) if bootp.ciaddr and str(bootp.ciaddr) != "0.0.0.0" else None
+    offered_ip = str(bootp.yiaddr) if bootp.yiaddr and str(bootp.yiaddr) != "0.0.0.0" else None
+    server_ip  = str(bootp.siaddr) if bootp.siaddr and str(bootp.siaddr) != "0.0.0.0" else None
+
+    # ── IP transport ──
+    src_ip = str(pkt[IP].src) if IP in pkt else None
+    dst_ip = str(pkt[IP].dst) if IP in pkt else None
+
+    # ── Decode DHCP message type ──
+    msg_type_raw = opts.get(53)
+    message_type = DhcpMessageType.from_int(int(msg_type_raw)) if msg_type_raw is not None else None
+
+    return DhcpLeaseEvent(
+        message_type=message_type,
+        client_mac=client_mac,
+        client_ip=client_ip,
+        client_identifier=_decode_client_identifier(opts),
+        requested_ip=_first_ip(opts.get(50)),
+        offered_ip=offered_ip,
+        server_ip=server_ip,
+        server_identifier=_first_ip(opts.get(54)),
+        hostname=_decode_bytes(opts.get(12)),
+        fqdn=_decode_fqdn(opts),
+        vendor_class=_decode_bytes(opts.get(60)),
+        user_class=_decode_bytes(opts.get(77)),
+        requested_options=_decode_requested_options(opts),
+        subnet_mask=_first_ip(opts.get(1)),
+        router=_first_ip(opts.get(3)),
+        dns_servers=_ip_list(opts.get(6)),
+        lease_time=int(opts[51]) if opts.get(51) is not None else None,
+        renewal_time=int(opts[58]) if opts.get(58) is not None else None,
+        rebinding_time=int(opts[59]) if opts.get(59) is not None else None,
+        unknown_options=_extract_unknown_options(opts),
+        src_ip=src_ip,
+        dst_ip=dst_ip,
+        interface=getattr(pkt, "sniffed_on", None),
+        timestamp=datetime.now(timezone.utc),
+    )

--- a/tests/test_dhcp_listener.py
+++ b/tests/test_dhcp_listener.py
@@ -1,0 +1,595 @@
+"""
+Unit tests for the DHCP lease request listener module.
+
+Covers:
+- DhcpMessageType enum helpers
+- DHCP option parser (_parse_dhcp_options)
+- Packet parser (_parse_packet) using synthetic scapy-like mock packets
+- DhcpLeaseEvent model properties (effective_ip, is_client_message, etc.)
+- DhcpListenerConfig subnet filter logic (_ip_in_networks, _build_subnet_networks)
+- DhcpListener filter pipeline (_passes_filters)
+- DhcpListener start/stop lifecycle (mocked AsyncSniffer)
+- Context-manager usage
+"""
+# pylint: disable=protected-access,missing-function-docstring
+import logging
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+import ipaddress
+
+import pytest
+
+from scapy.layers.dhcp import BOOTP, DHCP
+from scapy.layers.inet import IP
+
+from lanscape.core.dhcp_listener import (
+    DhcpListener,
+    DhcpListenerConfig,
+    DhcpLeaseEvent,
+    DhcpMessageType,
+    _build_subnet_networks,
+    _decode_bytes,
+    _ip_in_networks,
+    _mac_from_bytes,
+    _parse_dhcp_options,
+    _parse_packet,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Fixtures / helpers
+# ═══════════════════════════════════════════════════════════════════
+
+def _make_mock_packet(**kwargs) -> MagicMock:
+    """Build a minimal mock scapy packet with BOOTP and DHCP layers."""
+    chaddr = kwargs.get("chaddr", b"\xaa\xbb\xcc\xdd\xee\xff" + b"\x00" * 10)
+    ciaddr = kwargs.get("ciaddr", "0.0.0.0")
+    yiaddr = kwargs.get("yiaddr", "0.0.0.0")
+    siaddr = kwargs.get("siaddr", "0.0.0.0")
+    src_ip = kwargs.get("src_ip", "0.0.0.0")
+    dst_ip = kwargs.get("dst_ip", "255.255.255.255")
+    dhcp_options = kwargs.get("dhcp_options")
+
+    bootp = MagicMock(spec=BOOTP)
+    bootp.chaddr = chaddr
+    bootp.ciaddr = ciaddr
+    bootp.yiaddr = yiaddr
+    bootp.siaddr = siaddr
+
+    dhcp = MagicMock(spec=DHCP)
+    dhcp.options = dhcp_options or [
+        ("message-type", 1),
+        ("end", None),
+    ]
+
+    ip_layer = MagicMock(spec=IP)
+    ip_layer.src = src_ip
+    ip_layer.dst = dst_ip
+
+    pkt = MagicMock()
+    pkt.sniffed_on = "eth0"
+
+    def contains(cls):
+        return cls in (BOOTP, DHCP, IP)
+
+    pkt.__contains__ = MagicMock(side_effect=contains)
+
+    def getitem(cls):
+        if cls is BOOTP:
+            return bootp
+        if cls is DHCP:
+            return dhcp
+        if cls is IP:
+            return ip_layer
+        raise KeyError(cls)
+
+    pkt.__getitem__ = MagicMock(side_effect=getitem)
+    return pkt
+
+
+def _make_event(**kwargs) -> DhcpLeaseEvent:
+    """Create a minimal DhcpLeaseEvent with sensible defaults."""
+    defaults = {
+        "message_type": DhcpMessageType.DISCOVER,
+        "client_mac": "aa:bb:cc:dd:ee:ff",
+        "timestamp": datetime.now(timezone.utc),
+    }
+    defaults.update(kwargs)
+    return DhcpLeaseEvent(**defaults)
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  DhcpMessageType
+# ═══════════════════════════════════════════════════════════════════
+
+class TestDhcpMessageType:
+    """Tests for DhcpMessageType enum helpers."""
+    def test_known_values(self):
+        assert DhcpMessageType.DISCOVER == 1
+        assert DhcpMessageType.OFFER    == 2
+        assert DhcpMessageType.REQUEST  == 3
+        assert DhcpMessageType.ACK      == 5
+        assert DhcpMessageType.NAK      == 6
+
+    def test_from_int_known(self):
+        assert DhcpMessageType.from_int(1) is DhcpMessageType.DISCOVER
+        assert DhcpMessageType.from_int(5) is DhcpMessageType.ACK
+
+    def test_from_int_unknown(self):
+        assert DhcpMessageType.from_int(99) is None
+
+    def test_from_int_zero(self):
+        assert DhcpMessageType.from_int(0) is None
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Low-level helpers
+# ═══════════════════════════════════════════════════════════════════
+
+class TestDecodeBytes:
+    """Tests for the _decode_bytes helper."""
+    def test_bytes_to_str(self):
+        assert _decode_bytes(b"mydevice") == "mydevice"
+
+    def test_null_stripped(self):
+        assert _decode_bytes(b"host\x00") == "host"
+
+    def test_str_passthrough(self):
+        assert _decode_bytes("hello") == "hello"
+
+    def test_non_bytes_returns_none(self):
+        assert _decode_bytes(42) is None
+        assert _decode_bytes(None) is None
+
+
+class TestMacFromBytes:
+    """Tests for the _mac_from_bytes helper."""
+    def test_six_bytes(self):
+        assert _mac_from_bytes(b"\xaa\xbb\xcc\xdd\xee\xff") == "aa:bb:cc:dd:ee:ff"
+
+    def test_longer_bytes_truncates_to_six(self):
+        raw = b"\x00\x11\x22\x33\x44\x55\xde\xad"
+        assert _mac_from_bytes(raw) == "00:11:22:33:44:55"
+
+    def test_zero_mac(self):
+        assert _mac_from_bytes(b"\x00" * 6) == "00:00:00:00:00:00"
+
+
+class TestParseDhcpOptions:
+    """Tests for the _parse_dhcp_options helper."""
+    def test_empty(self):
+        assert not _parse_dhcp_options([])
+
+    def test_end_and_pad_are_skipped(self):
+        assert not _parse_dhcp_options([("end", None), ("pad", None)])
+
+    def test_named_option_decoded_to_code(self):
+        opts = _parse_dhcp_options([("message-type", 1), ("hostname", b"pc1")])
+        # 'message-type' → 53, 'hostname' is not in _OPTION_NAME_TO_CODE → stays 'hostname'
+        assert opts[53] == 1
+        # 'hostname' is not in our map (code 12 uses key 'hostname' in scapy output
+        # but our map key is 'hostname' → code 12)
+        assert opts[12] == b"pc1"
+
+    def test_integer_key_preserved(self):
+        opts = _parse_dhcp_options([(250, b"\x01\x02")])
+        assert opts[250] == b"\x01\x02"
+
+    def test_tuple_and_list_items(self):
+        opts = _parse_dhcp_options([["message-type", 3]])
+        assert opts[53] == 3
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  DhcpLeaseEvent model properties
+# ═══════════════════════════════════════════════════════════════════
+
+class TestDhcpLeaseEventProperties:
+    """Tests for DhcpLeaseEvent computed properties."""
+    def test_effective_ip_prefers_requested(self):
+        e = _make_event(
+            requested_ip="192.168.1.50",
+            offered_ip="192.168.1.51",
+            client_ip="192.168.1.52",
+        )
+        assert e.effective_ip == "192.168.1.50"
+
+    def test_effective_ip_falls_back_to_offered(self):
+        e = _make_event(offered_ip="192.168.1.51", client_ip="192.168.1.52")
+        assert e.effective_ip == "192.168.1.51"
+
+    def test_effective_ip_falls_back_to_client(self):
+        e = _make_event(client_ip="192.168.1.52")
+        assert e.effective_ip == "192.168.1.52"
+
+    def test_effective_ip_none_when_all_absent(self):
+        e = _make_event()
+        assert e.effective_ip is None
+
+    def test_is_client_message_discover(self):
+        assert _make_event(message_type=DhcpMessageType.DISCOVER).is_client_message
+        assert _make_event(message_type=DhcpMessageType.REQUEST).is_client_message
+        assert _make_event(message_type=DhcpMessageType.RELEASE).is_client_message
+
+    def test_is_client_message_offer_is_false(self):
+        assert not _make_event(message_type=DhcpMessageType.OFFER).is_client_message
+
+    def test_is_server_message_offer(self):
+        assert _make_event(message_type=DhcpMessageType.OFFER).is_server_message
+        assert _make_event(message_type=DhcpMessageType.ACK).is_server_message
+        assert _make_event(message_type=DhcpMessageType.NAK).is_server_message
+
+    def test_is_server_message_discover_is_false(self):
+        assert not _make_event(message_type=DhcpMessageType.DISCOVER).is_server_message
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Subnet filter helpers
+# ═══════════════════════════════════════════════════════════════════
+
+class TestBuildSubnetNetworks:
+    """Tests for _build_subnet_networks."""
+    def test_none_returns_none(self):
+        assert _build_subnet_networks(None) is None
+
+    def test_empty_list_returns_none(self):
+        assert _build_subnet_networks([]) is None
+
+    def test_valid_subnet(self):
+        result = _build_subnet_networks(["192.168.1.0/24"])
+        nets: list = result or []
+        assert len(nets) == 1
+        assert isinstance(nets[0], ipaddress.IPv4Network)
+
+    def test_invalid_subnet_skipped(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            nets = _build_subnet_networks(["not-a-subnet", "10.0.0.0/8"])
+        assert nets is not None and len(nets) == 1
+        assert "not-a-subnet" in caplog.text
+
+    def test_all_invalid_returns_none(self):
+        assert _build_subnet_networks(["bad1", "bad2"]) is None
+
+
+class TestIpInNetworks:
+    """Tests for the _ip_in_networks helper."""
+
+    nets: list  # assigned in setup_method
+
+    def setup_method(self):
+        self.nets = _build_subnet_networks(["192.168.1.0/24", "10.0.0.0/8"]) or []
+
+    def test_ip_in_first_network(self):
+        assert _ip_in_networks("192.168.1.100", self.nets)
+
+    def test_ip_in_second_network(self):
+        assert _ip_in_networks("10.5.6.7", self.nets)
+
+    def test_ip_not_in_any_network(self):
+        assert not _ip_in_networks("172.16.0.1", self.nets)
+
+    def test_none_ip_returns_false(self):
+        assert not _ip_in_networks(None, self.nets)
+
+    def test_no_filter_always_true(self):
+        assert _ip_in_networks("1.2.3.4", None)
+        assert _ip_in_networks(None, None)
+
+    def test_invalid_ip_returns_false(self):
+        assert not _ip_in_networks("not-an-ip", self.nets)
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  _parse_packet integration
+# ═══════════════════════════════════════════════════════════════════
+
+class TestParsePacket:
+    """Tests for the _parse_packet function."""
+    def test_discover_packet(self):
+        pkt = _make_mock_packet(
+            dhcp_options=[
+                ("message-type", 1),
+                ("hostname", b"my-laptop"),
+                ("vendor_class_id", b"MSFT 5.0"),
+                ("requested_addr", "192.168.1.50"),
+                ("param_req_list", [1, 3, 6, 15]),
+                ("end", None),
+            ]
+        )
+        event = _parse_packet(pkt)
+        assert event is not None
+        assert event.message_type == DhcpMessageType.DISCOVER
+        assert event.client_mac == "aa:bb:cc:dd:ee:ff"
+        assert event.hostname == "my-laptop"
+        assert event.vendor_class == "MSFT 5.0"
+        assert event.requested_ip == "192.168.1.50"
+        assert event.requested_options == [1, 3, 6, 15]
+
+    def test_offer_packet(self):
+        pkt = _make_mock_packet(
+            yiaddr="192.168.1.100",
+            siaddr="192.168.1.1",
+            dhcp_options=[
+                ("message-type", 2),
+                ("subnet_mask", "255.255.255.0"),
+                ("router", "192.168.1.1"),
+                ("name_server", ["8.8.8.8", "8.8.4.4"]),
+                ("lease_time", 86400),
+                ("server_id", "192.168.1.1"),
+                ("end", None),
+            ]
+        )
+        event = _parse_packet(pkt)
+        assert event is not None
+        assert event.message_type == DhcpMessageType.OFFER
+        assert event.offered_ip == "192.168.1.100"
+        assert event.subnet_mask == "255.255.255.0"
+        assert event.router == "192.168.1.1"
+        assert event.dns_servers == ["8.8.8.8", "8.8.4.4"]
+        assert event.lease_time == 86400
+        assert event.server_identifier == "192.168.1.1"
+
+    def test_client_ip_zero_becomes_none(self):
+        pkt = _make_mock_packet(ciaddr="0.0.0.0")
+        event = _parse_packet(pkt)
+        assert event.client_ip is None
+
+    def test_client_ip_nonzero_preserved(self):
+        pkt = _make_mock_packet(ciaddr="192.168.1.55")
+        event = _parse_packet(pkt)
+        assert event.client_ip == "192.168.1.55"
+
+    def test_mac_address_formatting(self):
+        chaddr = b"\x00\x1a\x2b\x3c\x4d\x5e" + b"\x00" * 10
+        pkt = _make_mock_packet(chaddr=chaddr)
+        event = _parse_packet(pkt)
+        assert event.client_mac == "00:1a:2b:3c:4d:5e"
+
+    def test_returns_none_without_dhcp_layer(self):
+        pkt = MagicMock()
+        pkt.__contains__ = MagicMock(return_value=False)
+        assert _parse_packet(pkt) is None
+
+    def test_interface_captured(self):
+        pkt = _make_mock_packet()
+        event = _parse_packet(pkt)
+        assert event.interface == "eth0"
+
+    def test_client_id_mac_type(self):
+        # Option 61: type byte 0x01 followed by 6-byte MAC
+        raw = b"\x01\xde\xad\xbe\xef\x00\x01"
+        pkt = _make_mock_packet(
+            dhcp_options=[
+                ("message-type", 3),
+                ("client_id", raw),
+                ("end", None),
+            ]
+        )
+        event = _parse_packet(pkt)
+        assert event.client_identifier == "de:ad:be:ef:00:01"
+
+    def test_param_req_list_as_bytes(self):
+        pkt = _make_mock_packet(
+            dhcp_options=[
+                ("message-type", 1),
+                ("param_req_list", bytes([1, 3, 6, 15, 28, 43])),
+                ("end", None),
+            ]
+        )
+        event = _parse_packet(pkt)
+        assert event.requested_options == [1, 3, 6, 15, 28, 43]
+
+    def test_unknown_options_collected(self):
+        pkt = _make_mock_packet(
+            dhcp_options=[
+                ("message-type", 1),
+                (250, b"\xde\xad"),
+                ("end", None),
+            ]
+        )
+        event = _parse_packet(pkt)
+        assert 250 in event.unknown_options
+
+    def test_fqdn_option_decoded(self):
+        # RFC 4702: 3 flag/rcode bytes + name
+        fqdn_raw = b"\x00\x00\x00" + b"myhost.local"
+        pkt = _make_mock_packet(
+            dhcp_options=[
+                ("message-type", 1),
+                ("FQDN", fqdn_raw),
+                ("end", None),
+            ]
+        )
+        event = _parse_packet(pkt)
+        assert event.fqdn == "myhost.local"
+
+    def test_timestamp_is_utc(self):
+        pkt = _make_mock_packet()
+        event = _parse_packet(pkt)
+        ts_value = event.model_dump().get("timestamp")
+        assert isinstance(ts_value, datetime) and ts_value.tzinfo is not None
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  DhcpListener._passes_filters
+# ═══════════════════════════════════════════════════════════════════
+
+class TestDhcpListenerFilters:
+    """Tests for DhcpListener filter logic."""
+    def _listener(self, **config_kwargs) -> DhcpListener:
+        cfg = DhcpListenerConfig(**config_kwargs)
+        return DhcpListener(cfg, on_event=lambda e: None)
+
+    # ── message type filter ──
+
+    def test_no_message_filter_passes_all(self):
+        listener = self._listener()
+        event = _make_event(message_type=DhcpMessageType.REQUEST)
+        assert listener._passes_filters(event)
+
+    def test_message_filter_passes_matching_type(self):
+        listener = self._listener(message_types=[DhcpMessageType.DISCOVER])
+        assert listener._passes_filters(_make_event(message_type=DhcpMessageType.DISCOVER))
+
+    def test_message_filter_blocks_non_matching_type(self):
+        listener = self._listener(message_types=[DhcpMessageType.DISCOVER])
+        assert not listener._passes_filters(_make_event(message_type=DhcpMessageType.REQUEST))
+
+    # ── include_server_messages ──
+
+    def test_server_messages_included_by_default(self):
+        listener = self._listener()
+        event = _make_event(message_type=DhcpMessageType.OFFER)
+        assert listener._passes_filters(event)
+
+    def test_server_messages_excluded_when_configured(self):
+        listener = self._listener(include_server_messages=False)
+        for msg_type in (DhcpMessageType.OFFER, DhcpMessageType.ACK, DhcpMessageType.NAK):
+            event = _make_event(message_type=msg_type)
+            assert not listener._passes_filters(event), f"Expected {msg_type} to be blocked"
+
+    def test_client_messages_not_affected_by_server_filter(self):
+        listener = self._listener(include_server_messages=False)
+        event = _make_event(message_type=DhcpMessageType.DISCOVER)
+        assert listener._passes_filters(event)
+
+    # ── subnet filter ──
+
+    def test_no_subnet_filter_passes_all(self):
+        listener = self._listener()
+        event = _make_event(requested_ip="172.16.5.10")
+        assert listener._passes_filters(event)
+
+    def test_subnet_filter_passes_ip_in_range(self):
+        listener = self._listener(subnet_filter=["192.168.1.0/24"])
+        event = _make_event(requested_ip="192.168.1.50")
+        assert listener._passes_filters(event)
+
+    def test_subnet_filter_blocks_ip_outside_range(self):
+        listener = self._listener(subnet_filter=["192.168.1.0/24"])
+        event = _make_event(requested_ip="10.0.0.50")
+        assert not listener._passes_filters(event)
+
+    def test_subnet_filter_checks_offered_ip(self):
+        listener = self._listener(subnet_filter=["192.168.1.0/24"])
+        event = _make_event(
+            message_type=DhcpMessageType.OFFER,
+            offered_ip="192.168.1.100",
+        )
+        assert listener._passes_filters(event)
+
+    def test_subnet_filter_checks_client_ip_as_fallback(self):
+        listener = self._listener(subnet_filter=["192.168.1.0/24"])
+        event = _make_event(
+            message_type=DhcpMessageType.REQUEST,
+            client_ip="192.168.1.10",
+        )
+        assert listener._passes_filters(event)
+
+    def test_subnet_filter_blocks_event_with_no_ip(self):
+        listener = self._listener(subnet_filter=["192.168.1.0/24"])
+        event = _make_event()  # no IPs set
+        assert not listener._passes_filters(event)
+
+    # ── combined filters ──
+
+    def test_combined_type_and_subnet_filter(self):
+        listener = self._listener(
+            subnet_filter=["192.168.1.0/24"],
+            message_types=[DhcpMessageType.DISCOVER],
+        )
+        # Right subnet, right type → pass
+        assert listener._passes_filters(
+            _make_event(message_type=DhcpMessageType.DISCOVER, requested_ip="192.168.1.5")
+        )
+        # Right subnet, wrong type → block
+        assert not listener._passes_filters(
+            _make_event(message_type=DhcpMessageType.REQUEST, requested_ip="192.168.1.5")
+        )
+        # Wrong subnet, right type → block
+        assert not listener._passes_filters(
+            _make_event(message_type=DhcpMessageType.DISCOVER, requested_ip="10.0.0.5")
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  DhcpListener lifecycle (mocked AsyncSniffer)
+# ═══════════════════════════════════════════════════════════════════
+
+class TestDhcpListenerLifecycle:
+    """Tests for DhcpListener start/stop lifecycle."""
+
+    def test_start_creates_sniffer(self):
+        mock_sniffer_instance = MagicMock()
+        mock_async_sniffer = MagicMock(return_value=mock_sniffer_instance)
+
+        cfg = DhcpListenerConfig()
+        events = []
+        listener = DhcpListener(cfg, on_event=events.append)
+
+        with patch("lanscape.core.dhcp_listener.AsyncSniffer", mock_async_sniffer):
+            listener.start()
+
+        mock_async_sniffer.assert_called_once()
+        mock_sniffer_instance.start.assert_called_once()
+        assert listener.is_running
+
+        listener.stop()
+        mock_sniffer_instance.stop.assert_called_once()
+        assert not listener.is_running
+
+    def test_stop_when_not_running_is_safe(self):
+        cfg = DhcpListenerConfig()
+        listener = DhcpListener(cfg, on_event=lambda e: None)
+        listener.stop()  # should not raise
+
+    def test_start_raises_when_already_running(self):
+        cfg = DhcpListenerConfig()
+        listener = DhcpListener(cfg, on_event=lambda e: None)
+        listener._running = True
+        with pytest.raises(RuntimeError, match="already running"):
+            listener.start()
+
+    def test_context_manager_calls_stop(self):
+        cfg = DhcpListenerConfig()
+        listener = DhcpListener(cfg, on_event=lambda e: None)
+        mock_sniffer = MagicMock()
+
+        # Patch start() so it just marks us as running without touching scapy
+        def fake_start():
+            listener._sniffer = mock_sniffer
+            listener._running = True
+
+        with patch.object(listener, "start", side_effect=fake_start):
+            with listener:
+                assert listener.is_running
+
+        mock_sniffer.stop.assert_called_once()
+        assert not listener.is_running
+
+    def test_context_manager_interface_filter(self):
+        cfg = DhcpListenerConfig(interface="eth0")
+        listener = DhcpListener(cfg, on_event=lambda e: None)
+        assert listener._config.interface == "eth0"
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  DhcpListenerConfig validation
+# ═══════════════════════════════════════════════════════════════════
+
+class TestDhcpListenerConfig:
+    """Tests for DhcpListenerConfig validation."""
+    def test_defaults(self):
+        cfg = DhcpListenerConfig()
+        assert cfg.subnet_filter is None
+        assert cfg.message_types is None
+        assert cfg.include_server_messages is True
+        assert cfg.interface is None
+
+    def test_subnet_filter_list(self):
+        cfg = DhcpListenerConfig(subnet_filter=["192.168.0.0/16", "10.0.0.0/8"])
+        assert len(cfg.subnet_filter) == 2
+
+    def test_message_types_list(self):
+        cfg = DhcpListenerConfig(message_types=[DhcpMessageType.DISCOVER, DhcpMessageType.REQUEST])
+        assert DhcpMessageType.DISCOVER in cfg.message_types


### PR DESCRIPTION
Demo PR showing the solution provided by AI from the following prompt (with instruction files)
```
make me a dhcp lease request listener module for lanscape. 
i want something where i can see any dhcp requests made within the lan, 
give option to filter on subnets, etc. 
I need a robust way to troubleshoot all relevant data correlated with a lease request. 

make sure the solution is elegant and pythonic
```