### PR TITLE
4.1.1 - Add Dependabot config (backend, docker, actions) and Dependabot-aware PR title check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+# Dependabot configuration for the LANScape Python library (backend).
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+#
+# Covers three ecosystems in this repo:
+#   1. pip            — backend Python deps declared in pyproject.toml
+#   2. docker         — base images in docker/ Dockerfiles + compose services
+#   3. github-actions — action versions pinned in .github/workflows/*
+#
+# NOTE: PRs target `main`. Titles use conventional-commit prefixes below
+# (build(deps)/build(deps-dev)/build(docker)/ci(actions)). The Quality - PR
+# Title check validates these for dependabot[bot] and — crucially — they carry
+# no leading X.Y.Z, so merging a bump does NOT trigger the release pipeline
+# (see release-trigger-main-push.yml). The bump ships with the next release.
+version: 2
+
+updates:
+  # ── Backend: Python dependencies (pyproject.toml) ───────────────────────
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "build(deps)"
+      prefix-development: "build(deps-dev)"
+    groups:
+      # One PR/week for all non-breaking Python bumps (runtime + dev tooling).
+      # Majors still arrive as individual PRs for deliberate review.
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # ── Docker: base images + compose service images ────────────────────────
+  # Scans docker/Dockerfile, docker/Dockerfile.arm64, docker/Dockerfile.dev
+  # and the docker/*compose*.yml files for tagged image updates.
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build(docker)"
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+
+  # ── CI: GitHub Actions used across workflows ────────────────────────────
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci(actions)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/quality-pr-title.yml
+++ b/.github/workflows/quality-pr-title.yml
@@ -23,7 +23,7 @@ jobs:
       # NOT trigger a release (see release-trigger-main-push.yml). The dep bump
       # rides along with the next human-authored release instead.
       - name: Validate Dependabot PR title format
-        if: ${{ github.actor == 'dependabot[bot]' }}
+        if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
@@ -44,7 +44,7 @@ jobs:
           echo "Format OK (Dependabot)"
 
       - name: Validate PR title format
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
@@ -63,7 +63,7 @@ jobs:
           echo "Format OK"
 
       - name: Check version is higher than latest release
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |

--- a/.github/workflows/quality-pr-title.yml
+++ b/.github/workflows/quality-pr-title.yml
@@ -17,7 +17,34 @@ jobs:
         with:
           fetch-depth: 0          # need full history for tag comparison
 
+      # Dependabot PRs intentionally carry NO version bump: their titles are
+      # conventional-commit style (e.g. "build(deps): bump X from 1.0 to 1.1"),
+      # which means merging them does NOT start with X.Y.Z and therefore does
+      # NOT trigger a release (see release-trigger-main-push.yml). The dep bump
+      # rides along with the next human-authored release instead.
+      - name: Validate Dependabot PR title format
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "PR title: '$PR_TITLE'"
+
+          # Must be a conventional commit, e.g. build(deps): / build(deps-dev): /
+          # build(docker): / ci(actions): — must NOT start with a version (a
+          # leading X.Y.Z here would wrongly trigger the release pipeline).
+          if echo "$PR_TITLE" | grep -qP '^\d+\.\d+\.\d+'; then
+            echo "::error::Dependabot PR title must not start with a version (X.Y.Z) — that would trigger a release on merge."
+            exit 1
+          fi
+          if ! echo "$PR_TITLE" | grep -qP '^(build|chore|ci)(\([^)]+\))?: .+'; then
+            echo "::error::Dependabot PR title must be a conventional commit, e.g. 'build(deps): bump X from 1.0 to 1.1'"
+            exit 1
+          fi
+
+          echo "Format OK (Dependabot)"
+
       - name: Validate PR title format
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
@@ -36,6 +63,7 @@ jobs:
           echo "Format OK"
 
       - name: Check version is higher than latest release
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |


### PR DESCRIPTION
## Description
Adds Dependabot version updates for the backend and makes the PR-title gate Dependabot-aware.

- **`.github/dependabot.yml`** (new):
  - **pip** — backend deps in `pyproject.toml` (runtime + `dev` extras), non-breaking bumps grouped into one weekly PR; majors individual.
  - **docker** — base images (`python:3.12-slim`) and compose service images under `docker/`.
  - **github-actions** — action pins across all workflows.
- **`.github/workflows/quality-pr-title.yml`**: now validates Dependabot conventional-commit titles (`build(deps): …`, `ci(actions): …`) while preserving the `X.Y.Z - Description` rule for human PRs. Dependabot titles intentionally carry **no** leading version, so merging a bump does **not** fire the release pipeline — the bump ships with the next human release.

## Type of Change
- [x] CI / build change

## Checklist
- [ ] Type hints — n/a (config only, no library code)
- [ ] Unit tests under `tests/` — n/a (no library behavior changed)
- [ ] New dependencies in `pyproject.toml` — n/a
- [ ] Module exports in `lanscape/__init__.py` — n/a

## Testing
- Both YAML files parse (`yaml.safe_load`).
- Verified the title regexes against real Dependabot strings (`build(deps)` / `build(deps-dev)` / `build(docker)` / `ci(actions)`, plus grouped `bump the <group> group` titles) and the human `X.Y.Z - …` format.

## Additional Notes
- Merging this PR cuts release **4.1.1** via the normal main-push pipeline.
- The companion UI configs were committed to `lanscape-ui` and `lanscape-web` directly (per request). The UI repos need `FONTAWESOME_TOKEN` in **Dependabot** secrets (separate store from Actions secrets) — not applicable to this backend repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
