### PR TITLE
4.1.2 - Auto patch-release Dependabot bumps & consolidate config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,19 +20,26 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "build(deps)"
       prefix-development: "build(deps-dev)"
     groups:
       # One PR/week for all non-breaking Python bumps (runtime + dev tooling).
-      # Majors still arrive as individual PRs for deliberate review.
       python-minor-patch:
         patterns:
           - "*"
         update-types:
           - minor
           - patch
+      # Majors are kept OUT of the safe group above, but still consolidated
+      # into a single PR (rather than one-per-dependency) so breaking changes
+      # get deliberate review without flooding the PR list.
+      python-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
 
   # ── Docker: base images + compose service images ────────────────────────
   # Scans docker/Dockerfile, docker/Dockerfile.arm64, docker/Dockerfile.dev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,10 @@
 #
 # NOTE: PRs target `main`. Titles use conventional-commit prefixes below
 # (build(deps)/build(deps-dev)/build(docker)/ci(actions)). The Quality - PR
-# Title check validates these for dependabot[bot] and — crucially — they carry
-# no leading X.Y.Z, so merging a bump does NOT trigger the release pipeline
-# (see release-trigger-main-push.yml). The bump ships with the next release.
+# Title check validates these for dependabot[bot]. They carry no leading
+# X.Y.Z, so on merge the release pipeline detects the build()/ci() prefix and
+# auto-increments the PATCH version to ship the bump (see
+# release-trigger-main-push.yml).
 version: 2
 
 updates:

--- a/.github/workflows/quality-pr-title.yml
+++ b/.github/workflows/quality-pr-title.yml
@@ -17,11 +17,11 @@ jobs:
         with:
           fetch-depth: 0          # need full history for tag comparison
 
-      # Dependabot PRs intentionally carry NO version bump: their titles are
-      # conventional-commit style (e.g. "build(deps): bump X from 1.0 to 1.1"),
-      # which means merging them does NOT start with X.Y.Z and therefore does
-      # NOT trigger a release (see release-trigger-main-push.yml). The dep bump
-      # rides along with the next human-authored release instead.
+      # Dependabot PRs carry NO explicit version: their titles are
+      # conventional-commit style (e.g. "build(deps): bump X from 1.0 to 1.1").
+      # On merge, release-trigger-main-push.yml detects the build()/ci() prefix
+      # and auto-increments the PATCH version to ship the bump. The title must
+      # NOT start with X.Y.Z — that path is reserved for human-chosen versions.
       - name: Validate Dependabot PR title format
         if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
         env:

--- a/.github/workflows/quality-pytest.yml
+++ b/.github/workflows/quality-pytest.yml
@@ -8,11 +8,13 @@ on:
       - 'lanscape/**.py'
       - 'tests/**.py'
       - 'scripts/**.py'
+      - 'pyproject.toml'   # dependency bumps (e.g. Dependabot) must re-run tests
   push:
     branches:
       - main
     paths:
       - '**.py'
+      - 'pyproject.toml'
   schedule:
     - cron: '0 0 * * 0'  # Runs at 00:00 UTC every Sunday
 

--- a/.github/workflows/release-trigger-main-push.yml
+++ b/.github/workflows/release-trigger-main-push.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0          # need tags to derive the next patch version
 
       - name: Extract version from commit message
         id: extract_version
@@ -26,9 +28,25 @@ jobs:
           COMMIT_MSG=$(git log -1 --pretty=%B | head -n1)
           VERSION_PART=$(echo "$COMMIT_MSG" | cut -d' ' -f1)
           if echo "$VERSION_PART" | grep -q '^[0-9]\+\.[0-9]\+\.[0-9]\+$'; then
+            # Human release PR: the version is chosen explicitly in the title.
             echo "version=$VERSION_PART" >> "$GITHUB_OUTPUT"
+            echo "Explicit release version: $VERSION_PART"
+          elif echo "$COMMIT_MSG" | grep -qE '^(build|ci)\([a-z-]+\): '; then
+            # Dependabot bump (build(deps)/build(deps-dev)/build(docker)/ci(actions)).
+            # It carries no version, so auto-increment the PATCH of the latest
+            # release to actually ship the bump instead of stranding it on main.
+            LATEST_TAG=$(git tag --list 'releases/*' --sort=-v:refname | head -n 1)
+            if [ -z "$LATEST_TAG" ]; then
+              echo "No releases/* tag found to derive a patch bump from. Skipping."
+              exit 0
+            fi
+            LATEST_VERSION="${LATEST_TAG#releases/}"
+            IFS='.' read -r MAJ MIN PAT <<< "$LATEST_VERSION"
+            NEW_VERSION="${MAJ}.${MIN}.$((PAT + 1))"
+            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+            echo "Dependabot bump detected — auto patch release: $LATEST_VERSION -> $NEW_VERSION"
           else
-            echo "Commit message does not start with a semantic version. Skipping tag creation."
+            echo "Commit message is neither a versioned release nor a Dependabot bump. Skipping tag creation."
           fi
 
       - name: Create tag


### PR DESCRIPTION
## Why

Two of the three commits from #85 landed *after* its squash-merge, so they were stranded on the (now-closed) `feat/dependabot` branch and never reached `main`. This re-applies them cleanly on top of current `main` (rebased past the `@v6` action bumps from #90), plus the Dependabot consolidation.

The `github.actor` → `github.event.pull_request.user.login` fix from #85 is **already in `main`** (shipped in 4.1.1) and is intentionally not re-included here.

## Changes

**Auto patch-release Dependabot bumps** — `release-trigger-main-push.yml`
- A Dependabot merge (title `build(...)`/`ci(...)`, no `X.Y.Z`) previously created no tag and stranded the bump on `main` until the next human release. Now the trigger detects the conventional-commit prefix and ships the bump by incrementing the **patch** of the latest `releases/*` tag, then runs the existing tag → release → publish pipeline.
- Checkout uses `fetch-depth: 0` so the latest release tag is available.
- Tag is pushed with the default `GITHUB_TOKEN`, which does not re-trigger workflows → no double-fire.

**Run pytest on dependency bumps** — `quality-pytest.yml`
- Added `pyproject.toml` to the PR and push `paths` filters so a Dependabot dep bump actually re-runs the suite (previously only `*.py` changes triggered it).

**Consolidate Dependabot PRs** — `dependabot.yml`
- Python majors now group into a single `python-major` PR instead of one-per-dependency (still separate from the minor/patch group for deliberate review).
- pip `open-pull-requests-limit` 10 → 5.

**Doc comments** updated in `dependabot.yml` / `quality-pr-title.yml` to match the new auto-release behavior.

## Notes
- Workflow-only change; no pytest coverage applies.
- Known edge case: two Dependabot PRs merging back-to-back compute the same patch from the same tag and the second `git tag` collides (errors, no corruption). Unlikely given weekly grouping; can add collision-retry later if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)