### PR TITLE
4.1.6 - Support psutil 7.x (fix snicaddr import error)

### DIFF
--- a/lanscape/core/net_tools/subnet_utils.py
+++ b/lanscape/core/net_tools/subnet_utils.py
@@ -1,5 +1,7 @@
 """Subnet/network utility functions."""
 
+from __future__ import annotations
+
 import ipaddress
 import logging
 import socket

--- a/lanscape/ui/ws/server.py
+++ b/lanscape/ui/ws/server.py
@@ -12,7 +12,10 @@ import uuid
 from typing import Optional, Callable
 
 import websockets
-from websockets.server import WebSocketServerProtocol
+# websockets>=15 re-exports WebSocketServerProtocol via a deprecation shim
+# (module __getattr__), which resolves at runtime but is invisible to pylint's
+# static analysis — hence the targeted no-name-in-module suppression.
+from websockets.server import WebSocketServerProtocol  # pylint: disable=no-name-in-module
 
 from lanscape.ui.ws.protocol import (
     WSRequest,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "psutil>=6.0,<7.0",
+    "psutil>=6.0,<8.0",
     "setuptools",
     "scapy>=2.3.2,<3.0",
     "tabulate==0.10.0",


### PR DESCRIPTION
@
## Problem

Dependabot PR #88 (`build(deps): update psutil requirement from <7.0,>=6.0 to >=6.0,<8.0`) fails the **Quality - Pytest** check on Python **3.10–3.13** across all OSes:

```
lanscape/core/net_tools/subnet_utils.py:80: in <module>
    def network_from_snicaddr(snicaddr: psutil._common.snicaddr) -> str | None:
E   AttributeError: module psutil._common has no attribute snicaddr
```

## Root cause

psutil **7.x** moved its private namedtuples (`snicaddr`, `sconn`, …) out of `psutil._common` into a new internal `psutil._ntuples` module. Our module-level type annotation referenced `psutil._common.snicaddr` directly, which is evaluated **at import time** — so the import blew up under psutil 7.x.

Python **3.14** was the lone passing version because PEP 649 defers annotation evaluation by default, so the missing attribute was never accessed.

## Fix

1. **psutil 7.x import** — add `from __future__ import annotations` to `subnet_utils.py` so annotations are stored as strings and never evaluated at import. Works under **both psutil 6.x and 7.x**; the function body only touches the stable public fields `.address`/`.netmask`/`.family`. Widen the constraint to `psutil>=6.0,<8.0`, superseding #88.

2. **pylint / websockets 16.0** — the `Quality - Pylint` workflow runs only on PRs that touch `.py` files, so it never ran on the pyproject-only #88. It surfaced a separate pre-existing issue here: websockets **16.0** exposes `WebSocketServerProtocol` via a deprecation shim (module `__getattr__`) that resolves at runtime — confirmed by the ws unit tests passing under websockets 16.0 — but is invisible to pylint, raising `E0611` (exit 2). Added a targeted `# pylint: disable=no-name-in-module` on the import. `useless-suppression` is disabled in `.pylintrc`, so the pragma is harmless under older websockets too.

## Verification

- Full pytest suite under psutil **7.2.2** locally: **944 passed, 11 skipped**.
- CI: all pytest matrix jobs green; `build` (pylint) matrix green; `validate-pr-title` green.
- pylint 10/10 locally on the full tracked file set.

Supersedes #88 (recommend closing that in favor of this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@