### PR TITLE
4.1.7 - Run quality workflows when their own YAML changes

### DIFF
--- a/.dispatch/instructions/house-rules.md
+++ b/.dispatch/instructions/house-rules.md
@@ -1,0 +1,76 @@
+# LANscape house rules
+
+Things this repo does differently. All of these are enforced by CI or by the
+release pipeline — getting them wrong fails a check or ships a bad release.
+
+## PR titles are the release version
+
+`quality-pr-title.yml` rejects any non-Dependabot PR whose title is not
+`X.Y.Z - Description`, and rejects `X.Y.Z` that is not strictly greater than the
+newest `releases/*` tag. Conventional-commit titles (`feat:`, `chore(scope):`)
+fail this check. Use `4.1.7 - Fix ARP parsing on macOS`.
+
+Commits inside the PR are still conventional — it is only the PR *title* that
+carries the version, because the squash commit becomes the release trigger.
+
+## Merging to main publishes a release
+
+`release-trigger-main-push.yml` reads the first line of the squashed commit. If
+it starts with `X.Y.Z` it creates and pushes `releases/X.Y.Z`, which fires the
+GitHub release, the cross-repo lanscape-ui build, and the PyPI publish. There is
+no "merge without releasing" path for a human PR. Treat every merge as a ship.
+
+Dependabot is the exception: its `build(...)` / `ci(...)` titles carry no
+version, and the workflow auto-increments the patch of the latest release.
+
+## Never hand-edit the version
+
+`pyproject.toml` says `version = "0.0.0"` on purpose. `release-pypi-publish.yml`
+`sed`s the real version in at build time from the git tag. Bumping it in a PR is
+always wrong.
+
+## The virtualenv is `.env/`, one per worktree
+
+Not `.venv/`. Every command in this repo is an editable install of the current
+checkout, so a shared interpreter makes parallel worktrees overwrite each
+other's `lanscape` install. Build a venv in each worktree:
+
+```
+python -m venv .env
+.env\Scripts\python.exe -m pip install -e ".[dev]"   # .env/bin/python on macOS/Linux
+```
+
+## Dev mode needs two things that are not in the repo
+
+`python -m lanscape` becomes the hot-reload dev environment only when
+`lanscape/local/.env` exists — that file is gitignored, so a fresh worktree does
+not have it, and it points at a *sibling clone of the `lanscape-ui` repo*. Copy
+it in when you start a worktree:
+
+```
+cp lanscape/local/.env.example lanscape/local/.env   # then set LANSCAPE_UI_PATH
+```
+
+Without it, `python -m lanscape` still binds both ports but serves **503** —
+`lanscape/ui/react_build/` ships empty and is filled by the release pipeline.
+For backend-only work use `python -m lanscape --ws-server`, which needs neither.
+
+`lanscape/local/` is excluded from the wheel (`pyproject.toml`, `MANIFEST.in`).
+Never import it from shipping code without the `try/except ImportError` guard
+`lanscape/ui/main.py` uses.
+
+## Integration tests do not run under plain pytest
+
+`pyproject.toml` sets `addopts = -m 'not integration'`, so `pytest tests/` skips
+them by design. They need Docker and their own harness:
+
+```
+tests/integration/run.ps1 -Build      # Windows
+tests/integration/run.sh --build      # macOS/Linux
+```
+
+## Dependencies live in `pyproject.toml` only
+
+Runtime deps in `[project.dependencies]`, tooling in
+`[project.optional-dependencies.dev]`. Never add a `requirements.txt` — CI
+installs from `pyproject.toml` and nothing else.

--- a/.dispatch/project.yaml
+++ b/.dispatch/project.yaml
@@ -1,0 +1,59 @@
+# .dispatch/ — self-contained, committable Dispatch config for this repo.
+# Discovered + loaded by Dispatch as the SOURCE OF TRUTH for authored config;
+# .data keeps only runtime state (chats, sessions, checkpoints). Safe to commit.
+name: lanscape
+worktreeRoot: .worktrees
+workflow:
+  profile: review
+  autoMerge: on-green
+
+instructions:
+  - file: house-rules.md
+
+# LANscape is a single Python package, so there is one real app here — run in
+# two documented modes. Both are the same entry point; `--ws-server` is the
+# escape hatch that skips the UI entirely (see CONTRIBUTING.md "Local dev mode").
+#
+# WHY THE COMMANDS GO THROUGH `.env\Scripts\python.exe` AND NOT BARE `python`:
+# CONTRIBUTING.md puts the virtualenv at `.env/` (not `.venv/`), and every
+# command below is an editable install of THIS checkout. Run with a bare
+# `python`, a worktree's `pip install -e .` silently repoints the global
+# `lanscape` at itself, so parallel worktrees fight over one install. Each
+# worktree therefore builds its own `.env/` in `install`.
+# Paths are Windows (cmd.exe rejects `.env/Scripts/...` with forward slashes —
+# verified). On macOS/Linux the same commands read `.env/bin/python`.
+subApps:
+  - id: lanscape
+    name: LANscape (UI + WebSocket backend)
+    cwd: .
+    install: python -m venv .env && .env\Scripts\python.exe -m pip install -e ".[dev]"
+    # In a source checkout that has `lanscape/local/.env`, this hands off to
+    # lanscape/local/dev_runner.py: Vite (from the sibling lanscape-ui repo) +
+    # a watchdog-reloading backend + a PWA window. Without that file it falls
+    # back to the bundled-UI flow, which binds both ports but serves 503 —
+    # `lanscape/ui/react_build/` is empty until release time. See house-rules.md.
+    dev: .env\Scripts\python.exe -m lanscape --ui-port {port} --ws-port {port2}
+    # `build` is deliberately NOT in the dev extras — quality-packaging.yml
+    # installs it as a separate step, so this does the same inline rather than
+    # leaving the Runner's Build button to fail on a missing module.
+    build: .env\Scripts\python.exe -m pip install --quiet build && .env\Scripts\python.exe -m build
+    # Integration tests are excluded here by pyproject's `-m 'not integration'`.
+    test: .env\Scripts\python.exe -m pytest tests/ -n auto --dist=loadscope -v
+    # 3000 = the Vite default dev_runner swaps to; 8766 = the WS default.
+    # (Outside dev mode the UI default is 5001, but --ui-port is explicit here.)
+    ports: [3000, 8766]
+    # The backend does not advertise itself — the UI takes the WS port as a
+    # query param, exactly as dev_runner.py builds it.
+    url: http://localhost:{port}?ws-server=localhost:{port2}
+
+  - id: lanscape-ws
+    name: LANscape WebSocket backend only (no UI)
+    cwd: .
+    install: python -m venv .env && .env\Scripts\python.exe -m pip install -e ".[dev]"
+    # The one mode with no external prerequisites: no sibling lanscape-ui repo,
+    # no `lanscape/local/.env`, no built webapp. Use it in a fresh worktree, or
+    # to point an already-running UI at this branch's backend.
+    dev: .env\Scripts\python.exe -m lanscape --ws-server --ws-port {port}
+    build: .env\Scripts\python.exe -m pip install --quiet build && .env\Scripts\python.exe -m build
+    test: .env\Scripts\python.exe -m pytest tests/ -n auto --dist=loadscope -v
+    ports: [8766]

--- a/.dispatch/skills/release/SKILL.md
+++ b/.dispatch/skills/release/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: release
+description: Cut a LANscape release or pre-release — choose the version, pick the lanscape-ui branch, push the tag, and know which artifacts each tag prefix produces. Use when asked to release, ship a version, cut an RC/beta/alpha, or publish to PyPI.
+---
+
+# Releasing LANscape
+
+The version exists **only as a git tag**. `pyproject.toml` stays at `0.0.0`;
+`release-pypi-publish.yml` seds the real version in at build time.
+
+## Two ways a release happens
+
+**1. Merging a PR to `main` (the normal path).** The PR title *is* the version —
+`X.Y.Z - Description`, higher than the newest `releases/*` tag. On merge,
+`release-trigger-main-push.yml` creates and pushes `releases/X.Y.Z`. Nothing
+else to do. Every human merge ships; there is no non-releasing merge.
+
+**2. Tagging directly (for pre-releases, or a non-`main` UI branch).** Use the
+script — it prints the current release / alpha / beta / rc tags first so you can
+pick the next version without guessing:
+
+```
+scripts/tasks/tag_release.ps1                      # Windows (VS Code: "Tag and Push Release")
+scripts/tasks/tag_release.sh                       # macOS/Linux
+scripts/tasks/tag_release.sh 4.2.0rc1 --ui-branch main
+```
+
+It prompts for the version and the UI branch if you do not pass them.
+
+## What the version string decides
+
+The script picks the tag prefix from the version, and
+`release-trigger-tag-push.yml` picks the artifacts from the prefix:
+
+| Version        | Tag                    | GitHub release | PyPI publish |
+| -------------- | ---------------------- | -------------- | ------------ |
+| `4.2.0`        | `releases/4.2.0`       | yes            | yes          |
+| `4.2.0rc1`     | `pre-releases/4.2.0rc1`| yes (pre)      | yes          |
+| `4.2.0b1`      | `pre-releases/4.2.0b1` | no             | yes          |
+| `4.2.0a1`      | `pre-releases/4.2.0a1` | no             | yes          |
+
+Anything else produces no release at all.
+
+## The UI build gates the publish
+
+Every release dispatches `webapp-build.yml` in `mdennis281/lanscape-ui`, waits
+up to 20 minutes, and pulls back the `webapp-dist` artifact — that is what fills
+the empty `lanscape/ui/react_build/`. The `publish` job requires
+`trigger-ui-build` to have succeeded, so **a failing UI build blocks the PyPI
+release.** Needs the `UI_BUILD_PAT` secret.
+
+If you pass `--ui-branch` anything other than `main`, the script does *not* push
+a tag; it runs `gh workflow run release-trigger-tag-push.yml` so the workflow
+can create the tag with that branch wired in. That path needs the `gh` CLI
+installed and authenticated.
+
+## Housekeeping
+
+`chore-cleanup-prereleases.yml` prunes `pre-releases/*` tags older than 90 days,
+monthly on the 1st. Run it by hand via workflow_dispatch with a different
+`max_age_days` if you need a deeper sweep.

--- a/.github/workflows/chore-wiki-sync.yml
+++ b/.github/workflows/chore-wiki-sync.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'docs/library/**'
+      - '.github/workflows/chore-wiki-sync.yml'   # changes here must re-sync
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/quality-integration-smoke.yml
+++ b/.github/workflows/quality-integration-smoke.yml
@@ -19,6 +19,7 @@ on:
       - 'lanscape/**.py'
       - 'tests/integration/**'
       - 'docker/**'
+      - '.github/workflows/quality-integration-smoke.yml'   # changes here must run themselves
   push:
     branches:
       - main
@@ -26,6 +27,7 @@ on:
       - 'lanscape/**.py'
       - 'tests/integration/**'
       - 'docker/**'
+      - '.github/workflows/quality-integration-smoke.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/quality-pylint.yml
+++ b/.github/workflows/quality-pylint.yml
@@ -7,11 +7,13 @@ on:
       - main
     paths:
       - '**.py'
+      - '.github/workflows/quality-pylint.yml'
   pull_request:
     branches:
       - main
     paths:
       - '**.py'
+      - '.github/workflows/quality-pylint.yml'   # changes here must lint themselves
 
 permissions:
   contents: read

--- a/.github/workflows/quality-pytest.yml
+++ b/.github/workflows/quality-pytest.yml
@@ -9,12 +9,14 @@ on:
       - 'tests/**.py'
       - 'scripts/**.py'
       - 'pyproject.toml'   # dependency bumps (e.g. Dependabot) must re-run tests
+      - '.github/workflows/quality-pytest.yml'   # changes here must test themselves
   push:
     branches:
       - main
     paths:
       - '**.py'
       - 'pyproject.toml'
+      - '.github/workflows/quality-pytest.yml'
   schedule:
     - cron: '0 0 * * 0'  # Runs at 00:00 UTC every Sunday
 

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,7 @@ pr-analysis/
 # tauri stuff
 node_modules
 setup_tauri
+
+# Dispatch per-task git worktrees (.dispatch/project.yaml `worktreeRoot`).
+# Resolves inside the repo, so without this every worktree is untracked noise.
+.worktrees/


### PR DESCRIPTION
Two things, both infrastructure — no library code changes.

## 1. Quality workflows now test themselves

A PR that edits `quality-pytest.yml` or `quality-pylint.yml` did **not** run pytest or pylint. Their path filters cover `**.py` and `pyproject.toml` but not the workflow file itself, so #94 (`actions/setup-python` 6 → 7, touching both) landed with only the packaging job as evidence:

```
build             pass    (packaging — no paths filter)
validate-pr-title pass
CodeQL            skipping
```

Each workflow is now listed in its own `paths:` filter, the way `quality-docker.yml` already does. Covers `pull_request` + `push` on `quality-pytest`, `quality-pylint` and `quality-integration-smoke`, plus `push` on `chore-wiki-sync`.

This PR is its own proof: it edits those workflow files, so Pytest and Pylint should now appear in its own check list.

After this lands, #94 needs a rebase to pick up the new filters before its bump is actually exercised.

## 2. Dispatch project config

Fills in `.dispatch/project.yaml` by auditing what this repo actually does. Two sub-apps, both the same entry point in its two documented modes (see CONTRIBUTING.md "Local dev mode"):

| id | dev command | ports |
|----|-------------|-------|
| `lanscape` | `python -m lanscape --ui-port {port} --ws-port {port2}` | 3000 (Vite), 8766 (WS) |
| `lanscape-ws` | `python -m lanscape --ws-server --ws-port {port}` | 8766 |

Commands go through a per-worktree `.env/` venv rather than a bare `python`: every command here is an editable install of the current checkout, so a shared interpreter makes parallel worktrees overwrite each other's `lanscape` install.

Verified in a fresh worktree with no venv: install clean, 944 passed / 11 skipped, sdist+wheel built, dev bound both allocated ports; and in a checkout with `lanscape/local/.env`, Vite served HTTP 200 against the sibling `lanscape-ui` repo.

Also adds `.dispatch/instructions/house-rules.md` (PR-title/version contract, the `.env/` venv, dev mode's two prerequisites, integration tests being Docker-only), `.dispatch/skills/release/SKILL.md` (tag prefix → artifacts, and the cross-repo UI build that gates PyPI), and `.worktrees/` to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)